### PR TITLE
Add backend endpoints for PandaScore data

### DIFF
--- a/src/main/java/rjkscore/application/service/PandaScoreService.java
+++ b/src/main/java/rjkscore/application/service/PandaScoreService.java
@@ -1,0 +1,9 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface PandaScoreService {
+    JsonNode getTeams();
+    JsonNode getPlayers();
+    JsonNode getMatches();
+}

--- a/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
@@ -1,0 +1,33 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.PandaScoreService;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class PandaScoreServiceImpl implements PandaScoreService {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public PandaScoreServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    @Override
+    public JsonNode getTeams() {
+        return pandaScoreApiClient.getTeams();
+    }
+
+    @Override
+    public JsonNode getPlayers() {
+        return pandaScoreApiClient.getPlayers();
+    }
+
+    @Override
+    public JsonNode getMatches() {
+        return pandaScoreApiClient.getMatches();
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -1,0 +1,58 @@
+package rjkscore.infrastructure.Client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Component
+public class PandaScoreApiClient {
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${pandascore.api.token}")
+    private String apiToken;
+
+    public PandaScoreApiClient(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    private JsonNode fetchList(String url) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + apiToken);
+        headers.set("Accept", "application/json");
+
+        HttpEntity<Void> requestEntity = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                url,
+                HttpMethod.GET,
+                requestEntity,
+                String.class
+            );
+            String json = response.getBody();
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return objectMapper.createArrayNode();
+        }
+    }
+
+    public JsonNode getTeams() {
+        return fetchList("https://api.pandascore.co/teams");
+    }
+
+    public JsonNode getPlayers() {
+        return fetchList("https://api.pandascore.co/players");
+    }
+
+    public JsonNode getMatches() {
+        return fetchList("https://api.pandascore.co/matches");
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Controller/PandaScoreController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/PandaScoreController.java
@@ -1,0 +1,35 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.PandaScoreService;
+
+@RestController
+@RequestMapping("/api")
+public class PandaScoreController {
+
+    private final PandaScoreService pandaScoreService;
+
+    public PandaScoreController(PandaScoreService pandaScoreService) {
+        this.pandaScoreService = pandaScoreService;
+    }
+
+    @GetMapping("/teams")
+    public JsonNode getTeams() {
+        return pandaScoreService.getTeams();
+    }
+
+    @GetMapping("/players")
+    public JsonNode getPlayers() {
+        return pandaScoreService.getPlayers();
+    }
+
+    @GetMapping("/matches")
+    public JsonNode getMatches() {
+        return pandaScoreService.getMatches();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -21,3 +21,4 @@ spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 # spring.jpa.hibernate.ddl-auto=update
 
 sportdevs.api.token=Qrn8BKnrJEeAbpVoEWWuuw
+pandascore.api.token=rmhig-Fuz23S9tfDT14uoycApeyVynxJLv2Ljazjz3nYGTT7S4s


### PR DESCRIPTION
## Summary
- support retrieving PandaScore teams, players and matches from backend
- proxy PandaScore API through new service and controller
- expose API token in `application.properties`

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fbbe20a588328b78f5a4df72c07b6