### PR TITLE
Add PandaScore league endpoints

### DIFF
--- a/src/main/java/rjkscore/application/service/PandaScoreService.java
+++ b/src/main/java/rjkscore/application/service/PandaScoreService.java
@@ -6,4 +6,12 @@ public interface PandaScoreService {
     JsonNode getTeams();
     JsonNode getPlayers();
     JsonNode getMatches();
+    JsonNode getLeagues();
+    JsonNode getLeague(String league);
+    JsonNode getLeagueTournaments(String league);
+    JsonNode getLeagueSeries(String league);
+    JsonNode getLeagueMatchesUpcoming(String league);
+    JsonNode getLeagueMatchesRunning(String league);
+    JsonNode getLeagueMatchesPast(String league);
+    JsonNode getLeagueMatches(String league);
 }

--- a/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
@@ -30,4 +30,44 @@ public class PandaScoreServiceImpl implements PandaScoreService {
     public JsonNode getMatches() {
         return pandaScoreApiClient.getMatches();
     }
+
+    @Override
+    public JsonNode getLeagues() {
+        return pandaScoreApiClient.getLeagues();
+    }
+
+    @Override
+    public JsonNode getLeague(String league) {
+        return pandaScoreApiClient.getLeague(league);
+    }
+
+    @Override
+    public JsonNode getLeagueTournaments(String league) {
+        return pandaScoreApiClient.getLeagueTournaments(league);
+    }
+
+    @Override
+    public JsonNode getLeagueSeries(String league) {
+        return pandaScoreApiClient.getLeagueSeries(league);
+    }
+
+    @Override
+    public JsonNode getLeagueMatchesUpcoming(String league) {
+        return pandaScoreApiClient.getLeagueMatchesUpcoming(league);
+    }
+
+    @Override
+    public JsonNode getLeagueMatchesRunning(String league) {
+        return pandaScoreApiClient.getLeagueMatchesRunning(league);
+    }
+
+    @Override
+    public JsonNode getLeagueMatchesPast(String league) {
+        return pandaScoreApiClient.getLeagueMatchesPast(league);
+    }
+
+    @Override
+    public JsonNode getLeagueMatches(String league) {
+        return pandaScoreApiClient.getLeagueMatches(league);
+    }
 }

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -55,4 +55,94 @@ public class PandaScoreApiClient {
     public JsonNode getMatches() {
         return fetchList("https://api.pandascore.co/matches");
     }
+
+    public JsonNode getLeagues() {
+        return fetchList("https://api.pandascore.co/leagues?sort=id&page=1&per_page=50");
+    }
+
+    public JsonNode getLeague(String league) {
+        return fetchList("https://api.pandascore.co/leagues/" + league);
+    }
+
+    public JsonNode getLeagueTournaments(String league) {
+        return fetchList(
+            "https://api.pandascore.co/leagues/" + league +
+            "/tournaments?filter[region][0]=ASIA&filter[tier][0]=a&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[has_bracket][0]=true&range[has_bracket][1]=true" +
+            "&range[region][0]=ASIA&range[region][1]=ASIA" +
+            "&range[tier][0]=a&range[tier][1]=a" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getLeagueSeries(String league) {
+        return fetchList(
+            "https://api.pandascore.co/leagues/" + league +
+            "/series?filter[winner_type][0]=Player" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getLeagueMatchesUpcoming(String league) {
+        return fetchList(
+            "https://api.pandascore.co/leagues/" + league +
+            "/matches/upcoming?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getLeagueMatchesRunning(String league) {
+        return fetchList(
+            "https://api.pandascore.co/leagues/" + league +
+            "/matches/running?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getLeagueMatchesPast(String league) {
+        return fetchList(
+            "https://api.pandascore.co/leagues/" + league +
+            "/matches/past?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getLeagueMatches(String league) {
+        return fetchList(
+            "https://api.pandascore.co/leagues/" + league +
+            "/matches?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/PandaScoreController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/PandaScoreController.java
@@ -1,6 +1,7 @@
 package rjkscore.infrastructure.Controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,5 +32,45 @@ public class PandaScoreController {
     @GetMapping("/matches")
     public JsonNode getMatches() {
         return pandaScoreService.getMatches();
+    }
+
+    @GetMapping("/pandascore/leagues")
+    public JsonNode getLeagues() {
+        return pandaScoreService.getLeagues();
+    }
+
+    @GetMapping("/pandascore/leagues/{league}")
+    public JsonNode getLeague(@PathVariable String league) {
+        return pandaScoreService.getLeague(league);
+    }
+
+    @GetMapping("/pandascore/leagues/{league}/tournaments")
+    public JsonNode getLeagueTournaments(@PathVariable String league) {
+        return pandaScoreService.getLeagueTournaments(league);
+    }
+
+    @GetMapping("/pandascore/leagues/{league}/series")
+    public JsonNode getLeagueSeries(@PathVariable String league) {
+        return pandaScoreService.getLeagueSeries(league);
+    }
+
+    @GetMapping("/pandascore/leagues/{league}/matches/upcoming")
+    public JsonNode getLeagueMatchesUpcoming(@PathVariable String league) {
+        return pandaScoreService.getLeagueMatchesUpcoming(league);
+    }
+
+    @GetMapping("/pandascore/leagues/{league}/matches/running")
+    public JsonNode getLeagueMatchesRunning(@PathVariable String league) {
+        return pandaScoreService.getLeagueMatchesRunning(league);
+    }
+
+    @GetMapping("/pandascore/leagues/{league}/matches/past")
+    public JsonNode getLeagueMatchesPast(@PathVariable String league) {
+        return pandaScoreService.getLeagueMatchesPast(league);
+    }
+
+    @GetMapping("/pandascore/leagues/{league}/matches")
+    public JsonNode getLeagueMatches(@PathVariable String league) {
+        return pandaScoreService.getLeagueMatches(league);
     }
 }


### PR DESCRIPTION
## Summary
- add PandaScore league API client methods
- extend PandaScoreService and impl with league methods
- expose new league routes in `PandaScoreController`

## Testing
- `mvn -q -DskipTests package` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ffc5ed3b4832890fafcca713831fe