### PR TITLE
Add PandaScore match endpoints

### DIFF
--- a/src/main/java/rjkscore/application/service/PandaScoreService.java
+++ b/src/main/java/rjkscore/application/service/PandaScoreService.java
@@ -6,6 +6,11 @@ public interface PandaScoreService {
     JsonNode getTeams();
     JsonNode getPlayers();
     JsonNode getMatches();
+    JsonNode getMatchesPast();
+    JsonNode getMatchesRunning();
+    JsonNode getMatchesUpcoming();
+    JsonNode getMatch(String matchIdOrSlug);
+    JsonNode getMatchOpponents(String matchIdOrSlug);
     JsonNode getLeagues();
     JsonNode getLeague(String league);
     JsonNode getLeagueTournaments(String league);

--- a/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
@@ -32,6 +32,31 @@ public class PandaScoreServiceImpl implements PandaScoreService {
     }
 
     @Override
+    public JsonNode getMatchesPast() {
+        return pandaScoreApiClient.getMatchesPast();
+    }
+
+    @Override
+    public JsonNode getMatchesRunning() {
+        return pandaScoreApiClient.getMatchesRunning();
+    }
+
+    @Override
+    public JsonNode getMatchesUpcoming() {
+        return pandaScoreApiClient.getMatchesUpcoming();
+    }
+
+    @Override
+    public JsonNode getMatch(String matchIdOrSlug) {
+        return pandaScoreApiClient.getMatch(matchIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getMatchOpponents(String matchIdOrSlug) {
+        return pandaScoreApiClient.getMatchOpponents(matchIdOrSlug);
+    }
+
+    @Override
     public JsonNode getLeagues() {
         return pandaScoreApiClient.getLeagues();
     }

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -56,6 +56,56 @@ public class PandaScoreApiClient {
         return fetchList("https://api.pandascore.co/matches");
     }
 
+    public JsonNode getMatchesPast() {
+        return fetchList(
+            "https://api.pandascore.co/matches/past?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getMatchesRunning() {
+        return fetchList(
+            "https://api.pandascore.co/matches/running?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getMatchesUpcoming() {
+        return fetchList(
+            "https://api.pandascore.co/matches/upcoming?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getMatch(String matchIdOrSlug) {
+        return fetchList("https://api.pandascore.co/matches/" + matchIdOrSlug);
+    }
+
+    public JsonNode getMatchOpponents(String matchIdOrSlug) {
+        return fetchList("https://api.pandascore.co/matches/" + matchIdOrSlug + "/opponents");
+    }
+
     public JsonNode getLeagues() {
         return fetchList("https://api.pandascore.co/leagues?sort=id&page=1&per_page=50");
     }

--- a/src/main/java/rjkscore/infrastructure/Controller/MatchController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/MatchController.java
@@ -1,0 +1,51 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.PandaScoreService;
+
+@RestController
+@RequestMapping("/api/pandascore")
+public class MatchController {
+
+    private final PandaScoreService pandaScoreService;
+
+    public MatchController(PandaScoreService pandaScoreService) {
+        this.pandaScoreService = pandaScoreService;
+    }
+
+    @GetMapping("/matches")
+    public JsonNode getMatches() {
+        return pandaScoreService.getMatches();
+    }
+
+    @GetMapping("/matches/past")
+    public JsonNode getMatchesPast() {
+        return pandaScoreService.getMatchesPast();
+    }
+
+    @GetMapping("/matches/running")
+    public JsonNode getMatchesRunning() {
+        return pandaScoreService.getMatchesRunning();
+    }
+
+    @GetMapping("/matches/upcoming")
+    public JsonNode getMatchesUpcoming() {
+        return pandaScoreService.getMatchesUpcoming();
+    }
+
+    @GetMapping("/matches/{match}")
+    public JsonNode getMatch(@PathVariable("match") String match) {
+        return pandaScoreService.getMatch(match);
+    }
+
+    @GetMapping("/matches/{match}/opponents")
+    public JsonNode getMatchOpponents(@PathVariable("match") String match) {
+        return pandaScoreService.getMatchOpponents(match);
+    }
+}


### PR DESCRIPTION
## Summary
- add MatchController for new endpoints
- support PandaScore match operations in service and API client

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network issues)*

------
https://chatgpt.com/codex/tasks/task_e_6850024c0a0c8328bf3a70d2088acecb