### PR TITLE
Add player endpoints to PandaScore API client

### DIFF
--- a/src/main/java/rjkscore/application/service/PlayerService.java
+++ b/src/main/java/rjkscore/application/service/PlayerService.java
@@ -1,0 +1,12 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface PlayerService {
+    JsonNode getPlayers();
+    JsonNode getPlayer(String playerIdOrSlug);
+    JsonNode getPlayerLeagues(String playerIdOrSlug);
+    JsonNode getPlayerMatches(String playerIdOrSlug);
+    JsonNode getPlayerSeries(String playerIdOrSlug);
+    JsonNode getPlayerTournaments(String playerIdOrSlug);
+}

--- a/src/main/java/rjkscore/application/service/impl/PlayerServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/PlayerServiceImpl.java
@@ -1,0 +1,47 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.PlayerService;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class PlayerServiceImpl implements PlayerService {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public PlayerServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    @Override
+    public JsonNode getPlayers() {
+        return pandaScoreApiClient.getPlayers();
+    }
+
+    @Override
+    public JsonNode getPlayer(String playerIdOrSlug) {
+        return pandaScoreApiClient.getPlayer(playerIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getPlayerLeagues(String playerIdOrSlug) {
+        return pandaScoreApiClient.getPlayerLeagues(playerIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getPlayerMatches(String playerIdOrSlug) {
+        return pandaScoreApiClient.getPlayerMatches(playerIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getPlayerSeries(String playerIdOrSlug) {
+        return pandaScoreApiClient.getPlayerSeries(playerIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getPlayerTournaments(String playerIdOrSlug) {
+        return pandaScoreApiClient.getPlayerTournaments(playerIdOrSlug);
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -49,7 +49,55 @@ public class PandaScoreApiClient {
     }
 
     public JsonNode getPlayers() {
-        return fetchList("https://api.pandascore.co/players");
+        return fetchList("https://api.pandascore.co/players?filter[videogame_id][0]=1&sort=birthday&page=1&per_page=50");
+    }
+
+    public JsonNode getPlayer(String playerIdOrSlug) {
+        return fetchList("https://api.pandascore.co/players/" + playerIdOrSlug);
+    }
+
+    public JsonNode getPlayerLeagues(String playerIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/players/" + playerIdOrSlug +
+            "/leagues?sort=id&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getPlayerMatches(String playerIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/players/" + playerIdOrSlug +
+            "/matches?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getPlayerSeries(String playerIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/players/" + playerIdOrSlug +
+            "/series?filter[winner_type][0]=Player" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getPlayerTournaments(String playerIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/players/" + playerIdOrSlug +
+            "/tournaments?filter[region][0]=ASIA&filter[tier][0]=a&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[has_bracket][0]=true&range[has_bracket][1]=true" +
+            "&range[region][0]=ASIA&range[region][1]=ASIA" +
+            "&range[tier][0]=a&range[tier][1]=a" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
     }
 
     public JsonNode getMatches() {

--- a/src/main/java/rjkscore/infrastructure/Controller/PlayerController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/PlayerController.java
@@ -1,0 +1,51 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.PlayerService;
+
+@RestController
+@RequestMapping("/api/pandascore")
+public class PlayerController {
+
+    private final PlayerService playerService;
+
+    public PlayerController(PlayerService playerService) {
+        this.playerService = playerService;
+    }
+
+    @GetMapping("/players")
+    public JsonNode getPlayers() {
+        return playerService.getPlayers();
+    }
+
+    @GetMapping("/players/{player}")
+    public JsonNode getPlayer(@PathVariable("player") String player) {
+        return playerService.getPlayer(player);
+    }
+
+    @GetMapping("/players/{player}/leagues")
+    public JsonNode getPlayerLeagues(@PathVariable("player") String player) {
+        return playerService.getPlayerLeagues(player);
+    }
+
+    @GetMapping("/players/{player}/matches")
+    public JsonNode getPlayerMatches(@PathVariable("player") String player) {
+        return playerService.getPlayerMatches(player);
+    }
+
+    @GetMapping("/players/{player}/series")
+    public JsonNode getPlayerSeries(@PathVariable("player") String player) {
+        return playerService.getPlayerSeries(player);
+    }
+
+    @GetMapping("/players/{player}/tournaments")
+    public JsonNode getPlayerTournaments(@PathVariable("player") String player) {
+        return playerService.getPlayerTournaments(player);
+    }
+}


### PR DESCRIPTION
## Summary
- extend `PandaScoreApiClient` with player-related API calls
- create `PlayerService` and its implementation
- add `PlayerController` exposing new REST endpoints for players

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500d665fa083289eef31d31879c7cd