### PR TITLE
Add team endpoints

### DIFF
--- a/src/main/java/rjkscore/application/service/TeamService.java
+++ b/src/main/java/rjkscore/application/service/TeamService.java
@@ -1,0 +1,11 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface TeamService {
+    JsonNode getTeams();
+    JsonNode getTeam(String teamIdOrSlug);
+    JsonNode getTeamLeagues(String teamIdOrSlug);
+    JsonNode getTeamMatches(String teamIdOrSlug);
+    JsonNode getTeamTournaments(String teamIdOrSlug);
+}

--- a/src/main/java/rjkscore/application/service/impl/TeamServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/TeamServiceImpl.java
@@ -1,0 +1,43 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.TeamService;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class TeamServiceImpl implements TeamService {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public TeamServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    @Override
+    public JsonNode getTeams() {
+        return pandaScoreApiClient.getTeams();
+    }
+
+    @Override
+    public JsonNode getTeam(String teamIdOrSlug) {
+        return pandaScoreApiClient.getTeam(teamIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getTeamLeagues(String teamIdOrSlug) {
+        return pandaScoreApiClient.getTeamLeagues(teamIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getTeamMatches(String teamIdOrSlug) {
+        return pandaScoreApiClient.getTeamMatches(teamIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getTeamTournaments(String teamIdOrSlug) {
+        return pandaScoreApiClient.getTeamTournaments(teamIdOrSlug);
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -45,7 +45,48 @@ public class PandaScoreApiClient {
     }
 
     public JsonNode getTeams() {
-        return fetchList("https://api.pandascore.co/teams");
+        return fetchList(
+            "https://api.pandascore.co/teams?filter[videogame_id][0]=1&sort=&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getTeam(String teamIdOrSlug) {
+        return fetchList("https://api.pandascore.co/teams/" + teamIdOrSlug);
+    }
+
+    public JsonNode getTeamLeagues(String teamIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/teams/" + teamIdOrSlug +
+            "/leagues?sort=id&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getTeamMatches(String teamIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/teams/" + teamIdOrSlug +
+            "/matches?filter[match_type][0]=all_games_played&filter[status][0]=canceled" +
+            "&filter[videogame][0]=1&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[draw][0]=true&range[draw][1]=true" +
+            "&range[forfeit][0]=true&range[forfeit][1]=true" +
+            "&range[match_type][0]=all_games_played&range[match_type][1]=all_games_played" +
+            "&range[status][0]=canceled&range[status][1]=canceled" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
+    }
+
+    public JsonNode getTeamTournaments(String teamIdOrSlug) {
+        return fetchList(
+            "https://api.pandascore.co/teams/" + teamIdOrSlug +
+            "/tournaments?filter[region][0]=ASIA&filter[tier][0]=a&filter[winner_type][0]=Player" +
+            "&range[detailed_stats][0]=true&range[detailed_stats][1]=true" +
+            "&range[has_bracket][0]=true&range[has_bracket][1]=true" +
+            "&range[region][0]=ASIA&range[region][1]=ASIA" +
+            "&range[tier][0]=a&range[tier][1]=a" +
+            "&range[winner_type][0]=Player&range[winner_type][1]=Player" +
+            "&sort=begin_at&page=1&per_page=50"
+        );
     }
 
     public JsonNode getPlayers() {

--- a/src/main/java/rjkscore/infrastructure/Controller/TeamController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/TeamController.java
@@ -1,0 +1,46 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.TeamService;
+
+@RestController
+@RequestMapping("/api/pandascore")
+public class TeamController {
+
+    private final TeamService teamService;
+
+    public TeamController(TeamService teamService) {
+        this.teamService = teamService;
+    }
+
+    @GetMapping("/teams")
+    public JsonNode getTeams() {
+        return teamService.getTeams();
+    }
+
+    @GetMapping("/teams/{team}")
+    public JsonNode getTeam(@PathVariable("team") String team) {
+        return teamService.getTeam(team);
+    }
+
+    @GetMapping("/teams/{team}/leagues")
+    public JsonNode getTeamLeagues(@PathVariable("team") String team) {
+        return teamService.getTeamLeagues(team);
+    }
+
+    @GetMapping("/teams/{team}/matches")
+    public JsonNode getTeamMatches(@PathVariable("team") String team) {
+        return teamService.getTeamMatches(team);
+    }
+
+    @GetMapping("/teams/{team}/tournaments")
+    public JsonNode getTeamTournaments(@PathVariable("team") String team) {
+        return teamService.getTeamTournaments(team);
+    }
+}


### PR DESCRIPTION
## Summary
- support team endpoints in API client
- add TeamService and implementation
- create TeamController for new routes

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685012e5ce388328b1903afa32d666a9