### PR TITLE
Add videogame PandaScore endpoints

### DIFF
--- a/src/main/java/rjkscore/application/service/PandaScoreService.java
+++ b/src/main/java/rjkscore/application/service/PandaScoreService.java
@@ -19,4 +19,11 @@ public interface PandaScoreService {
     JsonNode getLeagueMatchesRunning(String league);
     JsonNode getLeagueMatchesPast(String league);
     JsonNode getLeagueMatches(String league);
+    JsonNode getVideogames();
+    JsonNode getVideogame(String videogameIdOrSlug);
+    JsonNode getVideogameLeagues(String videogameIdOrSlug);
+    JsonNode getVideogameSeries(String videogameIdOrSlug);
+    JsonNode getVideogameTitles(String videogameIdOrSlug);
+    JsonNode getVideogameTournaments(String videogameIdOrSlug);
+    JsonNode getVideogameVersions(String videogameIdOrSlug);
 }

--- a/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/PandaScoreServiceImpl.java
@@ -95,4 +95,39 @@ public class PandaScoreServiceImpl implements PandaScoreService {
     public JsonNode getLeagueMatches(String league) {
         return pandaScoreApiClient.getLeagueMatches(league);
     }
+
+    @Override
+    public JsonNode getVideogames() {
+        return pandaScoreApiClient.getVideogames();
+    }
+
+    @Override
+    public JsonNode getVideogame(String videogameIdOrSlug) {
+        return pandaScoreApiClient.getVideogame(videogameIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getVideogameLeagues(String videogameIdOrSlug) {
+        return pandaScoreApiClient.getVideogameLeagues(videogameIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getVideogameSeries(String videogameIdOrSlug) {
+        return pandaScoreApiClient.getVideogameSeries(videogameIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getVideogameTitles(String videogameIdOrSlug) {
+        return pandaScoreApiClient.getVideogameTitles(videogameIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getVideogameTournaments(String videogameIdOrSlug) {
+        return pandaScoreApiClient.getVideogameTournaments(videogameIdOrSlug);
+    }
+
+    @Override
+    public JsonNode getVideogameVersions(String videogameIdOrSlug) {
+        return pandaScoreApiClient.getVideogameVersions(videogameIdOrSlug);
+    }
 }

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -284,4 +284,32 @@ public class PandaScoreApiClient {
             "&sort=begin_at&page=1&per_page=50"
         );
     }
+
+    public JsonNode getVideogames() {
+        return fetchList("https://api.pandascore.co/videogames?page=1&per_page=50");
+    }
+
+    public JsonNode getVideogame(String videogameIdOrSlug) {
+        return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug);
+    }
+
+    public JsonNode getVideogameLeagues(String videogameIdOrSlug) {
+        return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug + "/leagues");
+    }
+
+    public JsonNode getVideogameSeries(String videogameIdOrSlug) {
+        return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug + "/series");
+    }
+
+    public JsonNode getVideogameTitles(String videogameIdOrSlug) {
+        return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug + "/titles");
+    }
+
+    public JsonNode getVideogameTournaments(String videogameIdOrSlug) {
+        return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug + "/tournaments");
+    }
+
+    public JsonNode getVideogameVersions(String videogameIdOrSlug) {
+        return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug + "/versions");
+    }
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/VideogameController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/VideogameController.java
@@ -1,0 +1,56 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.PandaScoreService;
+
+@RestController
+@RequestMapping("/api/pandascore")
+public class VideogameController {
+
+    private final PandaScoreService pandaScoreService;
+
+    public VideogameController(PandaScoreService pandaScoreService) {
+        this.pandaScoreService = pandaScoreService;
+    }
+
+    @GetMapping("/videogames")
+    public JsonNode getVideogames() {
+        return pandaScoreService.getVideogames();
+    }
+
+    @GetMapping("/videogames/{videogame}")
+    public JsonNode getVideogame(@PathVariable("videogame") String videogame) {
+        return pandaScoreService.getVideogame(videogame);
+    }
+
+    @GetMapping("/videogames/{videogame}/leagues")
+    public JsonNode getVideogameLeagues(@PathVariable("videogame") String videogame) {
+        return pandaScoreService.getVideogameLeagues(videogame);
+    }
+
+    @GetMapping("/videogames/{videogame}/series")
+    public JsonNode getVideogameSeries(@PathVariable("videogame") String videogame) {
+        return pandaScoreService.getVideogameSeries(videogame);
+    }
+
+    @GetMapping("/videogames/{videogame}/titles")
+    public JsonNode getVideogameTitles(@PathVariable("videogame") String videogame) {
+        return pandaScoreService.getVideogameTitles(videogame);
+    }
+
+    @GetMapping("/videogames/{videogame}/tournaments")
+    public JsonNode getVideogameTournaments(@PathVariable("videogame") String videogame) {
+        return pandaScoreService.getVideogameTournaments(videogame);
+    }
+
+    @GetMapping("/videogames/{videogame}/versions")
+    public JsonNode getVideogameVersions(@PathVariable("videogame") String videogame) {
+        return pandaScoreService.getVideogameVersions(videogame);
+    }
+}


### PR DESCRIPTION
## Summary
- support videogame endpoints in `PandaScoreApiClient`
- expose videogame operations in `PandaScoreService`
- implement videogame methods in `PandaScoreServiceImpl`
- add new `VideogameController` for routes under `/api/pandascore`

## Testing
- `mvnw -q test` *(fails: Non-resolvable parent POM because network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_685016f0d07c83288605c152e8b417a4