### PR TITLE
Fix auth filter injection and document JWT key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # rjkscore
 Parte Backend de nuestro TFG rjkscore
+
+## Configuración
+
+La aplicación necesita una clave secreta para firmar y validar los JWT. Antes de
+ejecutar el servicio debes definir la variable de entorno `JWT_SECRET_KEY` con el
+valor que desees utilizar como clave.
+
+```bash
+export JWT_SECRET_KEY=mi_clave_secreta
+```
+
+Con esta variable presente se podrán generar y validar tokens correctamente.

--- a/src/main/java/rjkscore/configuration/JwtAuthenticationFilter.java
+++ b/src/main/java/rjkscore/configuration/JwtAuthenticationFilter.java
@@ -2,7 +2,6 @@ package rjkscore.configuration;
 
 import java.io.IOException;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -17,10 +16,13 @@ import jakarta.servlet.http.HttpServletResponse;
 
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
-    @Autowired
-    private JwtUtil jwtUtil;
-    @Autowired
-    private UserDetailsService userDetailsService;
+    private final JwtUtil jwtUtil;
+    private final UserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtUtil jwtUtil, UserDetailsService userDetailsService) {
+        this.jwtUtil = jwtUtil;
+        this.userDetailsService = userDetailsService;
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)

--- a/src/main/java/rjkscore/configuration/SecurityConfig.java
+++ b/src/main/java/rjkscore/configuration/SecurityConfig.java
@@ -14,6 +14,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.security.core.userdetails.UserDetailsService;
+
+import rjkscore.configuration.JwtUtil;
 
 @Configuration
 public class SecurityConfig {
@@ -24,8 +27,9 @@ public class SecurityConfig {
     }
 
     @Bean
-    public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter();
+    public JwtAuthenticationFilter jwtAuthenticationFilter(JwtUtil jwtUtil,
+                                                           UserDetailsService userDetailsService) {
+        return new JwtAuthenticationFilter(jwtUtil, userDetailsService);
     }
 
     @Bean


### PR DESCRIPTION
## Summary
- inject JwtUtil and UserDetailsService through JwtAuthenticationFilter constructor
- build JwtAuthenticationFilter bean with the dependencies
- document JWT_SECRET_KEY environment variable

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68501caedab08328b3d158983070f4fb