### PR TITLE
Implement favorites persistence

### DIFF
--- a/src/main/java/rjkscore/Domain/Favorite.java
+++ b/src/main/java/rjkscore/Domain/Favorite.java
@@ -1,0 +1,43 @@
+package rjkscore.Domain;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "favorites")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "favorite_id")
+    private Integer favoriteId;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id", nullable = false)
+    private AppUser user;
+
+    @Column(name = "item_type", nullable = false)
+    private String itemType;
+
+    @Column(name = "item_id", nullable = false)
+    private Integer itemId;
+
+    @Builder.Default
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt = LocalDateTime.now();
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/rjkscore/application/mapper/FavoriteMapper.java
+++ b/src/main/java/rjkscore/application/mapper/FavoriteMapper.java
@@ -1,0 +1,28 @@
+package rjkscore.application.mapper;
+
+import org.springframework.stereotype.Component;
+
+import rjkscore.Domain.AppUser;
+import rjkscore.Domain.Favorite;
+import rjkscore.infrastructure.Dto.Request.FavoriteRequestDto;
+import rjkscore.infrastructure.Dto.Response.FavoriteResponseDto;
+
+@Component
+public class FavoriteMapper {
+    public Favorite toEntity(FavoriteRequestDto dto, AppUser user) {
+        return Favorite.builder()
+                .user(user)
+                .itemType(dto.getItemType())
+                .itemId(dto.getItemId())
+                .build();
+    }
+
+    public FavoriteResponseDto toResponseDto(Favorite favorite) {
+        FavoriteResponseDto dto = new FavoriteResponseDto();
+        dto.setFavoriteId(favorite.getFavoriteId());
+        dto.setItemType(favorite.getItemType());
+        dto.setItemId(favorite.getItemId());
+        dto.setCreatedAt(favorite.getCreatedAt());
+        return dto;
+    }
+}

--- a/src/main/java/rjkscore/application/service/FavoriteService.java
+++ b/src/main/java/rjkscore/application/service/FavoriteService.java
@@ -1,0 +1,12 @@
+package rjkscore.application.service;
+
+import java.util.List;
+
+import rjkscore.infrastructure.Dto.Request.FavoriteRequestDto;
+import rjkscore.infrastructure.Dto.Response.FavoriteResponseDto;
+
+public interface FavoriteService {
+    FavoriteResponseDto addFavorite(String username, FavoriteRequestDto dto);
+    List<FavoriteResponseDto> getFavorites(String username);
+    void removeFavorite(Integer favoriteId, String username);
+}

--- a/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
@@ -1,0 +1,58 @@
+package rjkscore.application.service.impl;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import rjkscore.Domain.AppUser;
+import rjkscore.application.mapper.FavoriteMapper;
+import rjkscore.application.service.FavoriteService;
+import rjkscore.infrastructure.Dto.Request.FavoriteRequestDto;
+import rjkscore.infrastructure.Dto.Response.FavoriteResponseDto;
+import rjkscore.infrastructure.Repository.AppUserRepository;
+import rjkscore.infrastructure.Repository.FavoriteRepository;
+
+@Service
+public class FavoriteServiceImpl implements FavoriteService {
+
+    private final FavoriteRepository favoriteRepository;
+    private final AppUserRepository appUserRepository;
+    private final FavoriteMapper favoriteMapper;
+
+    public FavoriteServiceImpl(FavoriteRepository favoriteRepository,
+                               AppUserRepository appUserRepository,
+                               FavoriteMapper favoriteMapper) {
+        this.favoriteRepository = favoriteRepository;
+        this.appUserRepository = appUserRepository;
+        this.favoriteMapper = favoriteMapper;
+    }
+
+    @Override
+    public FavoriteResponseDto addFavorite(String username, FavoriteRequestDto dto) {
+        AppUser user = appUserRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        var favorite = favoriteRepository.save(favoriteMapper.toEntity(dto, user));
+        return favoriteMapper.toResponseDto(favorite);
+    }
+
+    @Override
+    public List<FavoriteResponseDto> getFavorites(String username) {
+        AppUser user = appUserRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        return favoriteRepository.findByUser(user).stream()
+                .map(favoriteMapper::toResponseDto)
+                .toList();
+    }
+
+    @Override
+    public void removeFavorite(Integer favoriteId, String username) {
+        AppUser user = appUserRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        var favorite = favoriteRepository.findById(favoriteId)
+                .orElseThrow(() -> new RuntimeException("Favorite not found"));
+        if (!favorite.getUser().getUserId().equals(user.getUserId())) {
+            throw new RuntimeException("Favorite does not belong to user");
+        }
+        favoriteRepository.delete(favorite);
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Controller/FavoriteController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/FavoriteController.java
@@ -1,0 +1,45 @@
+package rjkscore.infrastructure.Controller;
+
+import java.security.Principal;
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import rjkscore.application.service.FavoriteService;
+import rjkscore.infrastructure.Dto.Request.FavoriteRequestDto;
+import rjkscore.infrastructure.Dto.Response.FavoriteResponseDto;
+
+@RestController
+@RequestMapping("/api/favorites")
+public class FavoriteController {
+
+    private final FavoriteService favoriteService;
+
+    public FavoriteController(FavoriteService favoriteService) {
+        this.favoriteService = favoriteService;
+    }
+
+    @GetMapping
+    public List<FavoriteResponseDto> getFavorites(Principal principal) {
+        return favoriteService.getFavorites(principal.getName());
+    }
+
+    @PostMapping
+    public ResponseEntity<FavoriteResponseDto> addFavorite(@RequestBody FavoriteRequestDto dto,
+                                                           Principal principal) {
+        return ResponseEntity.ok(favoriteService.addFavorite(principal.getName(), dto));
+    }
+
+    @DeleteMapping("/{favoriteId}")
+    public ResponseEntity<Void> deleteFavorite(@PathVariable Integer favoriteId, Principal principal) {
+        favoriteService.removeFavorite(favoriteId, principal.getName());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Dto/Request/FavoriteRequestDto.java
+++ b/src/main/java/rjkscore/infrastructure/Dto/Request/FavoriteRequestDto.java
@@ -1,0 +1,11 @@
+package rjkscore.infrastructure.Dto.Request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FavoriteRequestDto {
+    private String itemType;
+    private Integer itemId;
+}

--- a/src/main/java/rjkscore/infrastructure/Dto/Response/FavoriteResponseDto.java
+++ b/src/main/java/rjkscore/infrastructure/Dto/Response/FavoriteResponseDto.java
@@ -1,0 +1,15 @@
+package rjkscore.infrastructure.Dto.Response;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FavoriteResponseDto {
+    private Integer favoriteId;
+    private String itemType;
+    private Integer itemId;
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/rjkscore/infrastructure/Repository/FavoriteRepository.java
+++ b/src/main/java/rjkscore/infrastructure/Repository/FavoriteRepository.java
@@ -1,0 +1,12 @@
+package rjkscore.infrastructure.Repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import rjkscore.Domain.AppUser;
+import rjkscore.Domain.Favorite;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Integer> {
+    List<Favorite> findByUser(AppUser user);
+}


### PR DESCRIPTION
## Summary
- add `Favorite` entity and repository
- support CRUD operations through new `FavoriteService` and controller
- map favorites to DTOs with `FavoriteMapper`

## Testing
- `./mvnw -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68512caa763083288bbd3fb95ba8493c