### PR TITLE
Add CustomUserDetailsService for JWT

### DIFF
--- a/src/main/java/rjkscore/application/service/impl/CustomUserDetailsService.java
+++ b/src/main/java/rjkscore/application/service/impl/CustomUserDetailsService.java
@@ -1,0 +1,35 @@
+package rjkscore.application.service.impl;
+
+import java.util.List;
+
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import rjkscore.Domain.AppUser;
+import rjkscore.infrastructure.Repository.AppUserRepository;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final AppUserRepository appUserRepository;
+
+    public CustomUserDetailsService(AppUserRepository appUserRepository) {
+        this.appUserRepository = appUserRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        AppUser user = appUserRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return new User(
+                user.getUsername(),
+                user.getPassword(),
+                List.of(new SimpleGrantedAuthority("ROLE_" + user.getRoles()))
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CustomUserDetailsService` that maps `AppUser` to Spring Security `User`
- inject repository and expose as `UserDetailsService` bean

## Testing
- `mvnw test` *(fails: Non-resolvable parent POM - network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68516d637574832897c86a1d8ed4d4b8