### PR TITLE
Enable user profile updates

### DIFF
--- a/src/main/java/rjkscore/application/service/AppUserService.java
+++ b/src/main/java/rjkscore/application/service/AppUserService.java
@@ -11,5 +11,7 @@ public interface AppUserService {
     AppUserResponseDto getUserById(Long userId);
 
     AppUserResponseDto updateUser(Long userId, UpdateUserDto dto);
+
+    AppUserResponseDto updateUser(String username, UpdateUserDto dto);
     AppUserResponseDto updateCoins(Long userId, int newCoins); 
 }

--- a/src/main/java/rjkscore/application/service/impl/AppUserServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/AppUserServiceImpl.java
@@ -3,6 +3,7 @@ package rjkscore.application.service.impl;
 import java.util.List;
 import java.util.NoSuchElementException;
 
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import rjkscore.Domain.AppUser;
@@ -16,10 +17,13 @@ import rjkscore.infrastructure.Repository.AppUserRepository;
 public class AppUserServiceImpl implements AppUserService {
     private final AppUserRepository repository;
     private final AppUserMapper mapper;
+    private final PasswordEncoder passwordEncoder;
 
-    public AppUserServiceImpl(AppUserRepository repository, AppUserMapper mapper) {
+    public AppUserServiceImpl(AppUserRepository repository, AppUserMapper mapper,
+                              PasswordEncoder passwordEncoder) {
         this.repository = repository;
         this.mapper = mapper;
+        this.passwordEncoder = passwordEncoder;
     }
 
     @Override
@@ -44,6 +48,22 @@ public class AppUserServiceImpl implements AppUserService {
             user.setEmail(dto.getEmail());
 
             return mapper.toResponseDto(repository.save(user));
+    }
+
+    @Override
+    public AppUserResponseDto updateUser(String username, UpdateUserDto dto) {
+        AppUser user = repository.findByUsername(username)
+                .orElseThrow(() -> new NoSuchElementException("user not found"));
+        if (dto.getUsername() != null) {
+            user.setUsername(dto.getUsername());
+        }
+        if (dto.getEmail() != null) {
+            user.setEmail(dto.getEmail());
+        }
+        if (dto.getPassword() != null) {
+            user.setPassword(passwordEncoder.encode(dto.getPassword()));
+        }
+        return mapper.toResponseDto(repository.save(user));
     }
 
     @Override

--- a/src/main/java/rjkscore/configuration/SecurityConfig.java
+++ b/src/main/java/rjkscore/configuration/SecurityConfig.java
@@ -37,6 +37,7 @@ public JwtAuthenticationFilter jwtAuthenticationFilter(JwtUtil jwtUtil, UserDeta
             .csrf(csrf -> csrf.disable())
             .authorizeHttpRequests(auth -> auth
                 .requestMatchers(HttpMethod.POST, "/api/favorites").authenticated()
+                .requestMatchers(HttpMethod.PUT, "/api/users/me").authenticated()
                 .requestMatchers("/api/**").permitAll()
             )
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));

--- a/src/main/java/rjkscore/infrastructure/Controller/AppUserController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/AppUserController.java
@@ -1,5 +1,6 @@
 package rjkscore.infrastructure.Controller;
 
+import java.security.Principal;
 import java.util.List;
 
 import org.springframework.http.ResponseEntity;
@@ -27,6 +28,12 @@ public class AppUserController {
     @GetMapping("/{userId}")
     public AppUserResponseDto getUserById(@PathVariable Long userId) {
         return service.getUserById(userId);
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<AppUserResponseDto> updateCurrentUser(Principal principal,
+                                                                @RequestBody UpdateUserDto dto) {
+        return ResponseEntity.ok(service.updateUser(principal.getName(), dto));
     }
 
     @PutMapping("/{userId}")

--- a/src/main/java/rjkscore/infrastructure/Dto/Request/UpdateUserDto.java
+++ b/src/main/java/rjkscore/infrastructure/Dto/Request/UpdateUserDto.java
@@ -14,5 +14,6 @@ import lombok.Setter;
 public class UpdateUserDto {
     private String username;
     private String email;
-    
+    private String password;
+
 }


### PR DESCRIPTION
## Summary
- allow users to edit username, email, or password
- add authenticated endpoint `/api/users/me`
- inject `PasswordEncoder` into `AppUserServiceImpl`
- secure the new endpoint in `SecurityConfig`

## Testing
- `mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvnw test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851ee1abe2483289a9f750af1363cc3