### PR TITLE
Add PandaScore CSGO API integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Bajo `/api/pandascore` están disponibles múltiples endpoints para consultar da
 - `GET /api/pandascore/players`, `/players/{id}` y subrutas equivalentes.
 - `GET /api/pandascore/matches`, `/matches/past`, `/matches/running`, etc.
 - `GET /api/pandascore/videogames`, `/videogames/{id}`, etc.
+- `GET /api/pandascore/csgo/...` para consultar datos específicos de Counter Strike (mapas, armas, jugadores, torneos, etc.).
 
 Consultar los controladores en `src/main/java/rjkscore/infrastructure/Controller` para ver el listado completo de rutas.
 

--- a/src/main/java/rjkscore/application/service/CsgoService.java
+++ b/src/main/java/rjkscore/application/service/CsgoService.java
@@ -1,0 +1,49 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface CsgoService {
+    // Games
+    JsonNode getGames();
+    JsonNode getGame(String gameId);
+    JsonNode getGameEvents(String gameId);
+    JsonNode getGameRounds(String gameId);
+
+    // Leagues
+    JsonNode getLeagues();
+
+    // Maps
+    JsonNode getMaps();
+    JsonNode getMap(String mapId);
+
+    // Matches
+    JsonNode getMatches();
+    JsonNode getMatchesPast();
+    JsonNode getMatchesRunning();
+    JsonNode getMatchesUpcoming();
+    JsonNode getMatch(String matchId);
+
+    // Stats
+    JsonNode getPlayerStats();
+    JsonNode getTeamStats();
+    JsonNode getTournamentStats();
+
+    // Players
+    JsonNode getPlayers();
+    JsonNode getPlayer(String playerId);
+
+    // Teams
+    JsonNode getTeams();
+    JsonNode getTeam(String teamId);
+
+    // Tournaments
+    JsonNode getTournaments();
+    JsonNode getTournamentsPast();
+    JsonNode getTournamentsRunning();
+    JsonNode getTournamentsUpcoming();
+    JsonNode getTournament(String tournamentId);
+
+    // Weapons
+    JsonNode getWeapons();
+    JsonNode getWeapon(String weaponId);
+}

--- a/src/main/java/rjkscore/application/service/impl/CsgoServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/CsgoServiceImpl.java
@@ -1,0 +1,157 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.CsgoService;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class CsgoServiceImpl implements CsgoService {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public CsgoServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    // Games
+    @Override
+    public JsonNode getGames() {
+        return pandaScoreApiClient.getCsgoGames();
+    }
+
+    @Override
+    public JsonNode getGame(String gameId) {
+        return pandaScoreApiClient.getCsgoGame(gameId);
+    }
+
+    @Override
+    public JsonNode getGameEvents(String gameId) {
+        return pandaScoreApiClient.getCsgoGameEvents(gameId);
+    }
+
+    @Override
+    public JsonNode getGameRounds(String gameId) {
+        return pandaScoreApiClient.getCsgoGameRounds(gameId);
+    }
+
+    // Leagues
+    @Override
+    public JsonNode getLeagues() {
+        return pandaScoreApiClient.getCsgoLeagues();
+    }
+
+    // Maps
+    @Override
+    public JsonNode getMaps() {
+        return pandaScoreApiClient.getCsgoMaps();
+    }
+
+    @Override
+    public JsonNode getMap(String mapId) {
+        return pandaScoreApiClient.getCsgoMap(mapId);
+    }
+
+    // Matches
+    @Override
+    public JsonNode getMatches() {
+        return pandaScoreApiClient.getCsgoMatches();
+    }
+
+    @Override
+    public JsonNode getMatchesPast() {
+        return pandaScoreApiClient.getCsgoMatchesPast();
+    }
+
+    @Override
+    public JsonNode getMatchesRunning() {
+        return pandaScoreApiClient.getCsgoMatchesRunning();
+    }
+
+    @Override
+    public JsonNode getMatchesUpcoming() {
+        return pandaScoreApiClient.getCsgoMatchesUpcoming();
+    }
+
+    @Override
+    public JsonNode getMatch(String matchId) {
+        return pandaScoreApiClient.getCsgoMatch(matchId);
+    }
+
+    // Stats
+    @Override
+    public JsonNode getPlayerStats() {
+        return pandaScoreApiClient.getCsgoPlayerStats();
+    }
+
+    @Override
+    public JsonNode getTeamStats() {
+        return pandaScoreApiClient.getCsgoTeamStats();
+    }
+
+    @Override
+    public JsonNode getTournamentStats() {
+        return pandaScoreApiClient.getCsgoTournamentStats();
+    }
+
+    // Players
+    @Override
+    public JsonNode getPlayers() {
+        return pandaScoreApiClient.getCsgoPlayers();
+    }
+
+    @Override
+    public JsonNode getPlayer(String playerId) {
+        return pandaScoreApiClient.getCsgoPlayer(playerId);
+    }
+
+    // Teams
+    @Override
+    public JsonNode getTeams() {
+        return pandaScoreApiClient.getCsgoTeams();
+    }
+
+    @Override
+    public JsonNode getTeam(String teamId) {
+        return pandaScoreApiClient.getCsgoTeam(teamId);
+    }
+
+    // Tournaments
+    @Override
+    public JsonNode getTournaments() {
+        return pandaScoreApiClient.getCsgoTournaments();
+    }
+
+    @Override
+    public JsonNode getTournamentsPast() {
+        return pandaScoreApiClient.getCsgoTournamentsPast();
+    }
+
+    @Override
+    public JsonNode getTournamentsRunning() {
+        return pandaScoreApiClient.getCsgoTournamentsRunning();
+    }
+
+    @Override
+    public JsonNode getTournamentsUpcoming() {
+        return pandaScoreApiClient.getCsgoTournamentsUpcoming();
+    }
+
+    @Override
+    public JsonNode getTournament(String tournamentId) {
+        return pandaScoreApiClient.getCsgoTournament(tournamentId);
+    }
+
+    // Weapons
+    @Override
+    public JsonNode getWeapons() {
+        return pandaScoreApiClient.getCsgoWeapons();
+    }
+
+    @Override
+    public JsonNode getWeapon(String weaponId) {
+        return pandaScoreApiClient.getCsgoWeapon(weaponId);
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -312,4 +312,109 @@ public class PandaScoreApiClient {
     public JsonNode getVideogameVersions(String videogameIdOrSlug) {
         return fetchList("https://api.pandascore.co/videogames/" + videogameIdOrSlug + "/versions");
     }
+
+    // --- CSGO endpoints ---
+    public JsonNode getCsgoGames() {
+        return fetchList("https://api.pandascore.co/csgo/games");
+    }
+
+    public JsonNode getCsgoGame(String id) {
+        return fetchList("https://api.pandascore.co/csgo/games/" + id);
+    }
+
+    public JsonNode getCsgoGameEvents(String id) {
+        return fetchList("https://api.pandascore.co/csgo/games/" + id + "/events");
+    }
+
+    public JsonNode getCsgoGameRounds(String id) {
+        return fetchList("https://api.pandascore.co/csgo/games/" + id + "/rounds");
+    }
+
+    public JsonNode getCsgoLeagues() {
+        return fetchList("https://api.pandascore.co/csgo/leagues");
+    }
+
+    public JsonNode getCsgoMaps() {
+        return fetchList("https://api.pandascore.co/csgo/maps");
+    }
+
+    public JsonNode getCsgoMap(String id) {
+        return fetchList("https://api.pandascore.co/csgo/maps/" + id);
+    }
+
+    public JsonNode getCsgoMatches() {
+        return fetchList("https://api.pandascore.co/csgo/matches");
+    }
+
+    public JsonNode getCsgoMatchesPast() {
+        return fetchList("https://api.pandascore.co/csgo/matches/past");
+    }
+
+    public JsonNode getCsgoMatchesRunning() {
+        return fetchList("https://api.pandascore.co/csgo/matches/running");
+    }
+
+    public JsonNode getCsgoMatchesUpcoming() {
+        return fetchList("https://api.pandascore.co/csgo/matches/upcoming");
+    }
+
+    public JsonNode getCsgoMatch(String id) {
+        return fetchList("https://api.pandascore.co/csgo/matches/" + id);
+    }
+
+    public JsonNode getCsgoPlayerStats() {
+        return fetchList("https://api.pandascore.co/csgo/stats/players");
+    }
+
+    public JsonNode getCsgoTeamStats() {
+        return fetchList("https://api.pandascore.co/csgo/stats/teams");
+    }
+
+    public JsonNode getCsgoTournamentStats() {
+        return fetchList("https://api.pandascore.co/csgo/stats/tournaments");
+    }
+
+    public JsonNode getCsgoPlayers() {
+        return fetchList("https://api.pandascore.co/csgo/players");
+    }
+
+    public JsonNode getCsgoPlayer(String id) {
+        return fetchList("https://api.pandascore.co/csgo/players/" + id);
+    }
+
+    public JsonNode getCsgoTeams() {
+        return fetchList("https://api.pandascore.co/csgo/teams");
+    }
+
+    public JsonNode getCsgoTeam(String id) {
+        return fetchList("https://api.pandascore.co/csgo/teams/" + id);
+    }
+
+    public JsonNode getCsgoTournaments() {
+        return fetchList("https://api.pandascore.co/csgo/tournaments");
+    }
+
+    public JsonNode getCsgoTournamentsPast() {
+        return fetchList("https://api.pandascore.co/csgo/tournaments/past");
+    }
+
+    public JsonNode getCsgoTournamentsRunning() {
+        return fetchList("https://api.pandascore.co/csgo/tournaments/running");
+    }
+
+    public JsonNode getCsgoTournamentsUpcoming() {
+        return fetchList("https://api.pandascore.co/csgo/tournaments/upcoming");
+    }
+
+    public JsonNode getCsgoTournament(String id) {
+        return fetchList("https://api.pandascore.co/csgo/tournaments/" + id);
+    }
+
+    public JsonNode getCsgoWeapons() {
+        return fetchList("https://api.pandascore.co/csgo/weapons");
+    }
+
+    public JsonNode getCsgoWeapon(String id) {
+        return fetchList("https://api.pandascore.co/csgo/weapons/" + id);
+    }
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/CsgoController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/CsgoController.java
@@ -1,0 +1,160 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.CsgoService;
+
+@RestController
+@RequestMapping("/api/pandascore/csgo")
+public class CsgoController {
+
+    private final CsgoService csgoService;
+
+    public CsgoController(CsgoService csgoService) {
+        this.csgoService = csgoService;
+    }
+
+    // Games
+    @GetMapping("/games")
+    public JsonNode getGames() {
+        return csgoService.getGames();
+    }
+
+    @GetMapping("/games/{id}")
+    public JsonNode getGame(@PathVariable("id") String id) {
+        return csgoService.getGame(id);
+    }
+
+    @GetMapping("/games/{id}/events")
+    public JsonNode getGameEvents(@PathVariable("id") String id) {
+        return csgoService.getGameEvents(id);
+    }
+
+    @GetMapping("/games/{id}/rounds")
+    public JsonNode getGameRounds(@PathVariable("id") String id) {
+        return csgoService.getGameRounds(id);
+    }
+
+    // Leagues
+    @GetMapping("/leagues")
+    public JsonNode getLeagues() {
+        return csgoService.getLeagues();
+    }
+
+    // Maps
+    @GetMapping("/maps")
+    public JsonNode getMaps() {
+        return csgoService.getMaps();
+    }
+
+    @GetMapping("/maps/{id}")
+    public JsonNode getMap(@PathVariable("id") String id) {
+        return csgoService.getMap(id);
+    }
+
+    // Matches
+    @GetMapping("/matches")
+    public JsonNode getMatches() {
+        return csgoService.getMatches();
+    }
+
+    @GetMapping("/matches/past")
+    public JsonNode getMatchesPast() {
+        return csgoService.getMatchesPast();
+    }
+
+    @GetMapping("/matches/running")
+    public JsonNode getMatchesRunning() {
+        return csgoService.getMatchesRunning();
+    }
+
+    @GetMapping("/matches/upcoming")
+    public JsonNode getMatchesUpcoming() {
+        return csgoService.getMatchesUpcoming();
+    }
+
+    @GetMapping("/matches/{id}")
+    public JsonNode getMatch(@PathVariable("id") String id) {
+        return csgoService.getMatch(id);
+    }
+
+    // Stats
+    @GetMapping("/stats/players")
+    public JsonNode getPlayerStats() {
+        return csgoService.getPlayerStats();
+    }
+
+    @GetMapping("/stats/teams")
+    public JsonNode getTeamStats() {
+        return csgoService.getTeamStats();
+    }
+
+    @GetMapping("/stats/tournaments")
+    public JsonNode getTournamentStats() {
+        return csgoService.getTournamentStats();
+    }
+
+    // Players
+    @GetMapping("/players")
+    public JsonNode getPlayers() {
+        return csgoService.getPlayers();
+    }
+
+    @GetMapping("/players/{id}")
+    public JsonNode getPlayer(@PathVariable("id") String id) {
+        return csgoService.getPlayer(id);
+    }
+
+    // Teams
+    @GetMapping("/teams")
+    public JsonNode getTeams() {
+        return csgoService.getTeams();
+    }
+
+    @GetMapping("/teams/{id}")
+    public JsonNode getTeam(@PathVariable("id") String id) {
+        return csgoService.getTeam(id);
+    }
+
+    // Tournaments
+    @GetMapping("/tournaments")
+    public JsonNode getTournaments() {
+        return csgoService.getTournaments();
+    }
+
+    @GetMapping("/tournaments/past")
+    public JsonNode getTournamentsPast() {
+        return csgoService.getTournamentsPast();
+    }
+
+    @GetMapping("/tournaments/running")
+    public JsonNode getTournamentsRunning() {
+        return csgoService.getTournamentsRunning();
+    }
+
+    @GetMapping("/tournaments/upcoming")
+    public JsonNode getTournamentsUpcoming() {
+        return csgoService.getTournamentsUpcoming();
+    }
+
+    @GetMapping("/tournaments/{id}")
+    public JsonNode getTournament(@PathVariable("id") String id) {
+        return csgoService.getTournament(id);
+    }
+
+    // Weapons
+    @GetMapping("/weapons")
+    public JsonNode getWeapons() {
+        return csgoService.getWeapons();
+    }
+
+    @GetMapping("/weapons/{id}")
+    public JsonNode getWeapon(@PathVariable("id") String id) {
+        return csgoService.getWeapon(id);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CsgoService` and its service implementation
- extend `PandaScoreApiClient` with `/csgo` endpoints
- expose new routes via `CsgoController`
- document CSGO endpoints in README

## Testing
- `mvn -q test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685286a48f8c832889587835fe037679