### PR TITLE
Expand favorite details

### DIFF
--- a/src/main/java/rjkscore/infrastructure/Dto/Response/FavoriteResponseDto.java
+++ b/src/main/java/rjkscore/infrastructure/Dto/Response/FavoriteResponseDto.java
@@ -2,6 +2,8 @@ package rjkscore.infrastructure.Dto.Response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -12,4 +14,5 @@ public class FavoriteResponseDto {
     private String itemType;
     private Integer itemId;
     private LocalDateTime createdAt;
+    private JsonNode itemData;
 }


### PR DESCRIPTION
## Summary
- return full item info for favorites by calling PandaScore based on itemType
- expose returned data via new `itemData` field in response DTO

## Testing
- `mvn test` *(fails: could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68528ffbe5248328ad356c66cdd65f38