### PR TITLE
Add Dota2 API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ public ResponseEntity<AppUserResponseDto> updateCurrentUser(Principal principal,
 
 - `DELETE /api/favorites/{id}` – Elimina un favorito.
 
-Internamente se consulta PandaScore para obtener información del elemento guardado:
+Internamente se consulta PandaScore para obtener información del elemento guardado.
+Los valores posibles de `itemType` incluyen los genéricos (`team`, `player`, `match`, `tournament`, `videogame`) y otros específicos como `csgo_team`, `csgo_player`, `dota2_team`, `dota2_player`, etc.
 
 ```java
 switch (type) {
@@ -156,6 +157,7 @@ Bajo `/api/pandascore` existen múltiples rutas para equipos, jugadores, partido
 - `GET /api/pandascore/matches`
 - `GET /api/pandascore/videogames`
 - Endpoints específicos de CSGO bajo `/api/pandascore/csgo` (maps, weapons, games, etc.).
+- Endpoints de Dota2 bajo `/api/pandascore/dota2` (abilities, heroes, items, matches, etc.).
 
 Todas estas rutas devuelven directamente la respuesta de PandaScore en formato JSON.
 

--- a/src/main/java/rjkscore/application/service/Dota2Service.java
+++ b/src/main/java/rjkscore/application/service/Dota2Service.java
@@ -1,0 +1,52 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface Dota2Service {
+    // Abilities
+    JsonNode getAbilities();
+    JsonNode getAbility(String abilityId);
+
+    // Games
+    JsonNode getGame(String gameId);
+
+    // Heroes
+    JsonNode getHeroes();
+    JsonNode getHero(String heroId);
+
+    // Items
+    JsonNode getItems();
+    JsonNode getItem(String itemId);
+
+    // Leagues
+    JsonNode getLeagues();
+
+    // Matches
+    JsonNode getMatches();
+    JsonNode getMatchesPast();
+    JsonNode getMatchesRunning();
+    JsonNode getMatchesUpcoming();
+    JsonNode getMatch(String matchId);
+
+    // Players
+    JsonNode getPlayers();
+    JsonNode getPlayer(String playerId);
+
+    // Series
+    JsonNode getSeries();
+    JsonNode getSeriesPast();
+    JsonNode getSeriesRunning();
+    JsonNode getSeriesUpcoming();
+    JsonNode getSeriesTeams(String seriesId);
+
+    // Teams
+    JsonNode getTeams();
+    JsonNode getTeam(String teamId);
+
+    // Tournaments
+    JsonNode getTournaments();
+    JsonNode getTournamentsPast();
+    JsonNode getTournamentsRunning();
+    JsonNode getTournamentsUpcoming();
+    JsonNode getTournament(String tournamentId);
+}

--- a/src/main/java/rjkscore/application/service/impl/Dota2ServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/Dota2ServiceImpl.java
@@ -1,0 +1,163 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.Dota2Service;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class Dota2ServiceImpl implements Dota2Service {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public Dota2ServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    // Abilities
+    @Override
+    public JsonNode getAbilities() {
+        return pandaScoreApiClient.getDota2Abilities();
+    }
+
+    @Override
+    public JsonNode getAbility(String abilityId) {
+        return pandaScoreApiClient.getDota2Ability(abilityId);
+    }
+
+    // Games
+    @Override
+    public JsonNode getGame(String gameId) {
+        return pandaScoreApiClient.getDota2Game(gameId);
+    }
+
+    // Heroes
+    @Override
+    public JsonNode getHeroes() {
+        return pandaScoreApiClient.getDota2Heroes();
+    }
+
+    @Override
+    public JsonNode getHero(String heroId) {
+        return pandaScoreApiClient.getDota2Hero(heroId);
+    }
+
+    // Items
+    @Override
+    public JsonNode getItems() {
+        return pandaScoreApiClient.getDota2Items();
+    }
+
+    @Override
+    public JsonNode getItem(String itemId) {
+        return pandaScoreApiClient.getDota2Item(itemId);
+    }
+
+    // Leagues
+    @Override
+    public JsonNode getLeagues() {
+        return pandaScoreApiClient.getDota2Leagues();
+    }
+
+    // Matches
+    @Override
+    public JsonNode getMatches() {
+        return pandaScoreApiClient.getDota2Matches();
+    }
+
+    @Override
+    public JsonNode getMatchesPast() {
+        return pandaScoreApiClient.getDota2MatchesPast();
+    }
+
+    @Override
+    public JsonNode getMatchesRunning() {
+        return pandaScoreApiClient.getDota2MatchesRunning();
+    }
+
+    @Override
+    public JsonNode getMatchesUpcoming() {
+        return pandaScoreApiClient.getDota2MatchesUpcoming();
+    }
+
+    @Override
+    public JsonNode getMatch(String matchId) {
+        return pandaScoreApiClient.getDota2Match(matchId);
+    }
+
+    // Players
+    @Override
+    public JsonNode getPlayers() {
+        return pandaScoreApiClient.getDota2Players();
+    }
+
+    @Override
+    public JsonNode getPlayer(String playerId) {
+        return pandaScoreApiClient.getDota2Player(playerId);
+    }
+
+    // Series
+    @Override
+    public JsonNode getSeries() {
+        return pandaScoreApiClient.getDota2Series();
+    }
+
+    @Override
+    public JsonNode getSeriesPast() {
+        return pandaScoreApiClient.getDota2SeriesPast();
+    }
+
+    @Override
+    public JsonNode getSeriesRunning() {
+        return pandaScoreApiClient.getDota2SeriesRunning();
+    }
+
+    @Override
+    public JsonNode getSeriesUpcoming() {
+        return pandaScoreApiClient.getDota2SeriesUpcoming();
+    }
+
+    @Override
+    public JsonNode getSeriesTeams(String seriesId) {
+        return pandaScoreApiClient.getDota2SeriesTeams(seriesId);
+    }
+
+    // Teams
+    @Override
+    public JsonNode getTeams() {
+        return pandaScoreApiClient.getDota2Teams();
+    }
+
+    @Override
+    public JsonNode getTeam(String teamId) {
+        return pandaScoreApiClient.getDota2Team(teamId);
+    }
+
+    // Tournaments
+    @Override
+    public JsonNode getTournaments() {
+        return pandaScoreApiClient.getDota2Tournaments();
+    }
+
+    @Override
+    public JsonNode getTournamentsPast() {
+        return pandaScoreApiClient.getDota2TournamentsPast();
+    }
+
+    @Override
+    public JsonNode getTournamentsRunning() {
+        return pandaScoreApiClient.getDota2TournamentsRunning();
+    }
+
+    @Override
+    public JsonNode getTournamentsUpcoming() {
+        return pandaScoreApiClient.getDota2TournamentsUpcoming();
+    }
+
+    @Override
+    public JsonNode getTournament(String tournamentId) {
+        return pandaScoreApiClient.getDota2Tournament(tournamentId);
+    }
+}

--- a/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
@@ -74,7 +74,11 @@ public List<FavoriteResponseDto> getFavorites(String username) {
                     case "csgo_map" -> itemData = pandaScoreApiClient.getCsgoMap(id);
                     case "csgo_weapon" -> itemData = pandaScoreApiClient.getCsgoWeapon(id);
                     case "series" -> itemData = pandaScoreApiClient.getSeries(id);
-
+                    case "dota2_team" -> itemData = pandaScoreApiClient.getDota2Team(id);
+                    case "dota2_player" -> itemData = pandaScoreApiClient.getDota2Player(id);
+                    case "dota2_tournament" -> itemData = pandaScoreApiClient.getDota2Tournament(id);
+                    case "dota2_match" -> itemData = pandaScoreApiClient.getDota2Match(id);
+                    case "dota2_game" -> itemData = pandaScoreApiClient.getDota2Game(id);
                     default -> itemData = null;
                 }
 

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -313,4 +313,113 @@ public class PandaScoreApiClient {
         return fetchList("https://api.pandascore.co/series/" + id);
     }
 
+    // --- DOTA2 endpoints ---
+    public JsonNode getDota2Abilities() {
+        return fetchList("https://api.pandascore.co/dota2/abilities");
+    }
+
+    public JsonNode getDota2Ability(String id) {
+        return fetchList("https://api.pandascore.co/dota2/abilities/" + id);
+    }
+
+    public JsonNode getDota2Game(String id) {
+        return fetchList("https://api.pandascore.co/dota2/games/" + id);
+    }
+
+    public JsonNode getDota2Heroes() {
+        return fetchList("https://api.pandascore.co/dota2/heroes");
+    }
+
+    public JsonNode getDota2Hero(String id) {
+        return fetchList("https://api.pandascore.co/dota2/heroes/" + id);
+    }
+
+    public JsonNode getDota2Items() {
+        return fetchList("https://api.pandascore.co/dota2/items");
+    }
+
+    public JsonNode getDota2Item(String id) {
+        return fetchList("https://api.pandascore.co/dota2/items/" + id);
+    }
+
+    public JsonNode getDota2Leagues() {
+        return fetchList("https://api.pandascore.co/dota2/leagues");
+    }
+
+    public JsonNode getDota2Matches() {
+        return fetchList("https://api.pandascore.co/dota2/matches");
+    }
+
+    public JsonNode getDota2MatchesPast() {
+        return fetchList("https://api.pandascore.co/dota2/matches/past");
+    }
+
+    public JsonNode getDota2MatchesRunning() {
+        return fetchList("https://api.pandascore.co/dota2/matches/running");
+    }
+
+    public JsonNode getDota2MatchesUpcoming() {
+        return fetchList("https://api.pandascore.co/dota2/matches/upcoming");
+    }
+
+    public JsonNode getDota2Match(String id) {
+        return fetchList("https://api.pandascore.co/dota2/matches/" + id);
+    }
+
+    public JsonNode getDota2Players() {
+        return fetchList("https://api.pandascore.co/dota2/players");
+    }
+
+    public JsonNode getDota2Player(String id) {
+        return fetchList("https://api.pandascore.co/dota2/players/" + id);
+    }
+
+    public JsonNode getDota2Series() {
+        return fetchList("https://api.pandascore.co/dota2/series");
+    }
+
+    public JsonNode getDota2SeriesPast() {
+        return fetchList("https://api.pandascore.co/dota2/series/past");
+    }
+
+    public JsonNode getDota2SeriesRunning() {
+        return fetchList("https://api.pandascore.co/dota2/series/running");
+    }
+
+    public JsonNode getDota2SeriesUpcoming() {
+        return fetchList("https://api.pandascore.co/dota2/series/upcoming");
+    }
+
+    public JsonNode getDota2SeriesTeams(String id) {
+        return fetchList("https://api.pandascore.co/dota2/series/" + id + "/teams");
+    }
+
+    public JsonNode getDota2Teams() {
+        return fetchList("https://api.pandascore.co/dota2/teams");
+    }
+
+    public JsonNode getDota2Team(String id) {
+        return fetchList("https://api.pandascore.co/dota2/teams/" + id);
+    }
+
+    public JsonNode getDota2Tournaments() {
+        return fetchList("https://api.pandascore.co/dota2/tournaments");
+    }
+
+    public JsonNode getDota2TournamentsPast() {
+        return fetchList("https://api.pandascore.co/dota2/tournaments/past");
+    }
+
+    public JsonNode getDota2TournamentsRunning() {
+        return fetchList("https://api.pandascore.co/dota2/tournaments/running");
+    }
+
+    public JsonNode getDota2TournamentsUpcoming() {
+        return fetchList("https://api.pandascore.co/dota2/tournaments/upcoming");
+    }
+
+    public JsonNode getDota2Tournament(String id) {
+        return fetchList("https://api.pandascore.co/dota2/tournaments/" + id);
+    }
+
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/Dota2Controller.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/Dota2Controller.java
@@ -1,0 +1,166 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.Dota2Service;
+
+@RestController
+@RequestMapping("/api/pandascore/dota2")
+public class Dota2Controller {
+
+    private final Dota2Service dota2Service;
+
+    public Dota2Controller(Dota2Service dota2Service) {
+        this.dota2Service = dota2Service;
+    }
+
+    // Abilities
+    @GetMapping("/abilities")
+    public JsonNode getAbilities() {
+        return dota2Service.getAbilities();
+    }
+
+    @GetMapping("/abilities/{id}")
+    public JsonNode getAbility(@PathVariable("id") String id) {
+        return dota2Service.getAbility(id);
+    }
+
+    // Games
+    @GetMapping("/games/{id}")
+    public JsonNode getGame(@PathVariable("id") String id) {
+        return dota2Service.getGame(id);
+    }
+
+    // Heroes
+    @GetMapping("/heroes")
+    public JsonNode getHeroes() {
+        return dota2Service.getHeroes();
+    }
+
+    @GetMapping("/heroes/{id}")
+    public JsonNode getHero(@PathVariable("id") String id) {
+        return dota2Service.getHero(id);
+    }
+
+    // Items
+    @GetMapping("/items")
+    public JsonNode getItems() {
+        return dota2Service.getItems();
+    }
+
+    @GetMapping("/items/{id}")
+    public JsonNode getItem(@PathVariable("id") String id) {
+        return dota2Service.getItem(id);
+    }
+
+    // Leagues
+    @GetMapping("/leagues")
+    public JsonNode getLeagues() {
+        return dota2Service.getLeagues();
+    }
+
+    // Matches
+    @GetMapping("/matches")
+    public JsonNode getMatches() {
+        return dota2Service.getMatches();
+    }
+
+    @GetMapping("/matches/past")
+    public JsonNode getMatchesPast() {
+        return dota2Service.getMatchesPast();
+    }
+
+    @GetMapping("/matches/running")
+    public JsonNode getMatchesRunning() {
+        return dota2Service.getMatchesRunning();
+    }
+
+    @GetMapping("/matches/upcoming")
+    public JsonNode getMatchesUpcoming() {
+        return dota2Service.getMatchesUpcoming();
+    }
+
+    @GetMapping("/matches/{id}")
+    public JsonNode getMatch(@PathVariable("id") String id) {
+        return dota2Service.getMatch(id);
+    }
+
+    // Players
+    @GetMapping("/players")
+    public JsonNode getPlayers() {
+        return dota2Service.getPlayers();
+    }
+
+    @GetMapping("/players/{id}")
+    public JsonNode getPlayer(@PathVariable("id") String id) {
+        return dota2Service.getPlayer(id);
+    }
+
+    // Series
+    @GetMapping("/series")
+    public JsonNode getSeries() {
+        return dota2Service.getSeries();
+    }
+
+    @GetMapping("/series/past")
+    public JsonNode getSeriesPast() {
+        return dota2Service.getSeriesPast();
+    }
+
+    @GetMapping("/series/running")
+    public JsonNode getSeriesRunning() {
+        return dota2Service.getSeriesRunning();
+    }
+
+    @GetMapping("/series/upcoming")
+    public JsonNode getSeriesUpcoming() {
+        return dota2Service.getSeriesUpcoming();
+    }
+
+    @GetMapping("/series/{id}/teams")
+    public JsonNode getSeriesTeams(@PathVariable("id") String id) {
+        return dota2Service.getSeriesTeams(id);
+    }
+
+    // Teams
+    @GetMapping("/teams")
+    public JsonNode getTeams() {
+        return dota2Service.getTeams();
+    }
+
+    @GetMapping("/teams/{id}")
+    public JsonNode getTeam(@PathVariable("id") String id) {
+        return dota2Service.getTeam(id);
+    }
+
+    // Tournaments
+    @GetMapping("/tournaments")
+    public JsonNode getTournaments() {
+        return dota2Service.getTournaments();
+    }
+
+    @GetMapping("/tournaments/past")
+    public JsonNode getTournamentsPast() {
+        return dota2Service.getTournamentsPast();
+    }
+
+    @GetMapping("/tournaments/running")
+    public JsonNode getTournamentsRunning() {
+        return dota2Service.getTournamentsRunning();
+    }
+
+    @GetMapping("/tournaments/upcoming")
+    public JsonNode getTournamentsUpcoming() {
+        return dota2Service.getTournamentsUpcoming();
+    }
+
+    @GetMapping("/tournaments/{id}")
+    public JsonNode getTournament(@PathVariable("id") String id) {
+        return dota2Service.getTournament(id);
+    }
+}


### PR DESCRIPTION
## Summary
- expose PandaScore Dota2 endpoints via new `Dota2Controller` and service
- extend `PandaScoreApiClient` with Dota2 methods
- allow Dota2 items in favorites
- document new endpoints and favorite item types

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852b81015a8832886972e43a9a62904