### PR TITLE
Add LoL endpoints and favorites support

### DIFF
--- a/src/main/java/rjkscore/application/service/LolService.java
+++ b/src/main/java/rjkscore/application/service/LolService.java
@@ -1,0 +1,59 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface LolService {
+    // Champions
+    JsonNode getChampions();
+    JsonNode getChampion(String championId);
+
+    // Items
+    JsonNode getItems();
+    JsonNode getItem(String itemId);
+
+    // Leagues
+    JsonNode getLeagues();
+
+    // Masteries
+    JsonNode getMasteries();
+    JsonNode getMastery(String masteryId);
+
+    // Matches
+    JsonNode getMatches();
+    JsonNode getMatchesPast();
+    JsonNode getMatchesRunning();
+    JsonNode getMatchesUpcoming();
+    JsonNode getMatch(String matchId);
+
+    // Players
+    JsonNode getPlayers();
+    JsonNode getPlayer(String playerId);
+
+    // Runes
+    JsonNode getRunesReforged();
+    JsonNode getRunesReforgedPaths();
+    JsonNode getRunesReforgedPath(String pathId);
+    JsonNode getRuneReforged(String runeId);
+
+    // Series
+    JsonNode getSeries();
+    JsonNode getSeriesPast();
+    JsonNode getSeriesRunning();
+    JsonNode getSeriesUpcoming();
+    JsonNode getSeriesTeams(String seriesId);
+
+    // Teams
+    JsonNode getTeams();
+    JsonNode getTeam(String teamId);
+
+    // Spells
+    JsonNode getSpells();
+    JsonNode getSpell(String spellId);
+
+    // Tournaments
+    JsonNode getTournaments();
+    JsonNode getTournament(String tournamentId);
+    JsonNode getTournamentsPast();
+    JsonNode getTournamentsRunning();
+    JsonNode getTournamentsUpcoming();
+}

--- a/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
@@ -79,6 +79,16 @@ public List<FavoriteResponseDto> getFavorites(String username) {
                     case "dota2_tournament" -> itemData = pandaScoreApiClient.getDota2Tournament(id);
                     case "dota2_match" -> itemData = pandaScoreApiClient.getDota2Match(id);
                     case "dota2_game" -> itemData = pandaScoreApiClient.getDota2Game(id);
+                    case "lol_team" -> itemData = pandaScoreApiClient.getLolTeam(id);
+                    case "lol_player" -> itemData = pandaScoreApiClient.getLolPlayer(id);
+                    case "lol_match" -> itemData = pandaScoreApiClient.getLolMatch(id);
+                    case "lol_tournament" -> itemData = pandaScoreApiClient.getLolTournament(id);
+                    case "lol_champion" -> itemData = pandaScoreApiClient.getLolChampion(id);
+                    case "lol_item" -> itemData = pandaScoreApiClient.getLolItem(id);
+                    case "lol_mastery" -> itemData = pandaScoreApiClient.getLolMastery(id);
+                    case "lol_spell" -> itemData = pandaScoreApiClient.getLolSpell(id);
+                    case "lol_rune" -> itemData = pandaScoreApiClient.getLolRuneReforged(id);
+                    case "lol_rune_path" -> itemData = pandaScoreApiClient.getLolRunesReforgedPath(id);
                     default -> itemData = null;
                 }
 

--- a/src/main/java/rjkscore/application/service/impl/LolServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/LolServiceImpl.java
@@ -1,0 +1,187 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+import com.fasterxml.jackson.databind.JsonNode;
+import rjkscore.application.service.LolService;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class LolServiceImpl implements LolService {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public LolServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    // Champions
+    @Override
+    public JsonNode getChampions() {
+        return pandaScoreApiClient.getLolChampions();
+    }
+
+    @Override
+    public JsonNode getChampion(String championId) {
+        return pandaScoreApiClient.getLolChampion(championId);
+    }
+
+    // Items
+    @Override
+    public JsonNode getItems() {
+        return pandaScoreApiClient.getLolItems();
+    }
+
+    @Override
+    public JsonNode getItem(String itemId) {
+        return pandaScoreApiClient.getLolItem(itemId);
+    }
+
+    // Leagues
+    @Override
+    public JsonNode getLeagues() {
+        return pandaScoreApiClient.getLolLeagues();
+    }
+
+    // Masteries
+    @Override
+    public JsonNode getMasteries() {
+        return pandaScoreApiClient.getLolMasteries();
+    }
+
+    @Override
+    public JsonNode getMastery(String masteryId) {
+        return pandaScoreApiClient.getLolMastery(masteryId);
+    }
+
+    // Matches
+    @Override
+    public JsonNode getMatches() {
+        return pandaScoreApiClient.getLolMatches();
+    }
+
+    @Override
+    public JsonNode getMatchesPast() {
+        return pandaScoreApiClient.getLolMatchesPast();
+    }
+
+    @Override
+    public JsonNode getMatchesRunning() {
+        return pandaScoreApiClient.getLolMatchesRunning();
+    }
+
+    @Override
+    public JsonNode getMatchesUpcoming() {
+        return pandaScoreApiClient.getLolMatchesUpcoming();
+    }
+
+    @Override
+    public JsonNode getMatch(String matchId) {
+        return pandaScoreApiClient.getLolMatch(matchId);
+    }
+
+    // Players
+    @Override
+    public JsonNode getPlayers() {
+        return pandaScoreApiClient.getLolPlayers();
+    }
+
+    @Override
+    public JsonNode getPlayer(String playerId) {
+        return pandaScoreApiClient.getLolPlayer(playerId);
+    }
+
+    // Runes
+    @Override
+    public JsonNode getRunesReforged() {
+        return pandaScoreApiClient.getLolRunesReforged();
+    }
+
+    @Override
+    public JsonNode getRunesReforgedPaths() {
+        return pandaScoreApiClient.getLolRunesReforgedPaths();
+    }
+
+    @Override
+    public JsonNode getRunesReforgedPath(String pathId) {
+        return pandaScoreApiClient.getLolRunesReforgedPath(pathId);
+    }
+
+    @Override
+    public JsonNode getRuneReforged(String runeId) {
+        return pandaScoreApiClient.getLolRuneReforged(runeId);
+    }
+
+    // Series
+    @Override
+    public JsonNode getSeries() {
+        return pandaScoreApiClient.getLolSeries();
+    }
+
+    @Override
+    public JsonNode getSeriesPast() {
+        return pandaScoreApiClient.getLolSeriesPast();
+    }
+
+    @Override
+    public JsonNode getSeriesRunning() {
+        return pandaScoreApiClient.getLolSeriesRunning();
+    }
+
+    @Override
+    public JsonNode getSeriesUpcoming() {
+        return pandaScoreApiClient.getLolSeriesUpcoming();
+    }
+
+    @Override
+    public JsonNode getSeriesTeams(String seriesId) {
+        return pandaScoreApiClient.getLolSeriesTeams(seriesId);
+    }
+
+    // Teams
+    @Override
+    public JsonNode getTeams() {
+        return pandaScoreApiClient.getLolTeams();
+    }
+
+    @Override
+    public JsonNode getTeam(String teamId) {
+        return pandaScoreApiClient.getLolTeam(teamId);
+    }
+
+    // Spells
+    @Override
+    public JsonNode getSpells() {
+        return pandaScoreApiClient.getLolSpells();
+    }
+
+    @Override
+    public JsonNode getSpell(String spellId) {
+        return pandaScoreApiClient.getLolSpell(spellId);
+    }
+
+    // Tournaments
+    @Override
+    public JsonNode getTournaments() {
+        return pandaScoreApiClient.getLolTournaments();
+    }
+
+    @Override
+    public JsonNode getTournament(String tournamentId) {
+        return pandaScoreApiClient.getLolTournament(tournamentId);
+    }
+
+    @Override
+    public JsonNode getTournamentsPast() {
+        return pandaScoreApiClient.getLolTournamentsPast();
+    }
+
+    @Override
+    public JsonNode getTournamentsRunning() {
+        return pandaScoreApiClient.getLolTournamentsRunning();
+    }
+
+    @Override
+    public JsonNode getTournamentsUpcoming() {
+        return pandaScoreApiClient.getLolTournamentsUpcoming();
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -422,4 +422,133 @@ public class PandaScoreApiClient {
         return fetchList("https://api.pandascore.co/dota2/tournaments/" + id);
     }
 
+    // --- LOL endpoints ---
+    public JsonNode getLolChampions() {
+        return fetchList("https://api.pandascore.co/lol/champions");
+    }
+
+    public JsonNode getLolChampion(String id) {
+        return fetchList("https://api.pandascore.co/lol/champions/" + id);
+    }
+
+    public JsonNode getLolItems() {
+        return fetchList("https://api.pandascore.co/lol/items");
+    }
+
+    public JsonNode getLolItem(String id) {
+        return fetchList("https://api.pandascore.co/lol/items/" + id);
+    }
+
+    public JsonNode getLolLeagues() {
+        return fetchList("https://api.pandascore.co/lol/leagues");
+    }
+
+    public JsonNode getLolMasteries() {
+        return fetchList("https://api.pandascore.co/lol/masteries");
+    }
+
+    public JsonNode getLolMastery(String id) {
+        return fetchList("https://api.pandascore.co/lol/masteries/" + id);
+    }
+
+    public JsonNode getLolMatches() {
+        return fetchList("https://api.pandascore.co/lol/matches");
+    }
+
+    public JsonNode getLolMatchesPast() {
+        return fetchList("https://api.pandascore.co/lol/matches/past");
+    }
+
+    public JsonNode getLolMatchesRunning() {
+        return fetchList("https://api.pandascore.co/lol/matches/running");
+    }
+
+    public JsonNode getLolMatchesUpcoming() {
+        return fetchList("https://api.pandascore.co/lol/matches/upcoming");
+    }
+
+    public JsonNode getLolMatch(String id) {
+        return fetchList("https://api.pandascore.co/lol/matches/" + id);
+    }
+
+    public JsonNode getLolPlayers() {
+        return fetchList("https://api.pandascore.co/lol/players");
+    }
+
+    public JsonNode getLolPlayer(String id) {
+        return fetchList("https://api.pandascore.co/lol/players/" + id);
+    }
+
+    public JsonNode getLolRunesReforged() {
+        return fetchList("https://api.pandascore.co/lol/runes-reforged");
+    }
+
+    public JsonNode getLolRunesReforgedPaths() {
+        return fetchList("https://api.pandascore.co/lol/runes-reforged-paths");
+    }
+
+    public JsonNode getLolRunesReforgedPath(String id) {
+        return fetchList("https://api.pandascore.co/lol/runes-reforged-paths/" + id);
+    }
+
+    public JsonNode getLolRuneReforged(String id) {
+        return fetchList("https://api.pandascore.co/lol/runes-reforged/" + id);
+    }
+
+    public JsonNode getLolSeries() {
+        return fetchList("https://api.pandascore.co/lol/series");
+    }
+
+    public JsonNode getLolSeriesPast() {
+        return fetchList("https://api.pandascore.co/lol/series/past");
+    }
+
+    public JsonNode getLolSeriesRunning() {
+        return fetchList("https://api.pandascore.co/lol/series/running");
+    }
+
+    public JsonNode getLolSeriesUpcoming() {
+        return fetchList("https://api.pandascore.co/lol/series/upcoming");
+    }
+
+    public JsonNode getLolSeriesTeams(String id) {
+        return fetchList("https://api.pandascore.co/lol/series/" + id + "/teams");
+    }
+
+    public JsonNode getLolTeams() {
+        return fetchList("https://api.pandascore.co/lol/teams");
+    }
+
+    public JsonNode getLolTeam(String id) {
+        return fetchList("https://api.pandascore.co/lol/teams/" + id);
+    }
+
+    public JsonNode getLolSpells() {
+        return fetchList("https://api.pandascore.co/lol/spells");
+    }
+
+    public JsonNode getLolSpell(String id) {
+        return fetchList("https://api.pandascore.co/lol/spells/" + id);
+    }
+
+    public JsonNode getLolTournaments() {
+        return fetchList("https://api.pandascore.co/lol/tournaments");
+    }
+
+    public JsonNode getLolTournament(String id) {
+        return fetchList("https://api.pandascore.co/lol/tournaments/" + id);
+    }
+
+    public JsonNode getLolTournamentsPast() {
+        return fetchList("https://api.pandascore.co/lol/tournaments/past");
+    }
+
+    public JsonNode getLolTournamentsRunning() {
+        return fetchList("https://api.pandascore.co/lol/tournaments/running");
+    }
+
+    public JsonNode getLolTournamentsUpcoming() {
+        return fetchList("https://api.pandascore.co/lol/tournaments/upcoming");
+    }
+
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/LolController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/LolController.java
@@ -1,0 +1,192 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.LolService;
+
+@RestController
+@RequestMapping("/api/pandascore/lol")
+public class LolController {
+
+    private final LolService lolService;
+
+    public LolController(LolService lolService) {
+        this.lolService = lolService;
+    }
+
+    // Champions
+    @GetMapping("/champions")
+    public JsonNode getChampions() {
+        return lolService.getChampions();
+    }
+
+    @GetMapping("/champions/{id}")
+    public JsonNode getChampion(@PathVariable("id") String id) {
+        return lolService.getChampion(id);
+    }
+
+    // Items
+    @GetMapping("/items")
+    public JsonNode getItems() {
+        return lolService.getItems();
+    }
+
+    @GetMapping("/items/{id}")
+    public JsonNode getItem(@PathVariable("id") String id) {
+        return lolService.getItem(id);
+    }
+
+    // Leagues
+    @GetMapping("/leagues")
+    public JsonNode getLeagues() {
+        return lolService.getLeagues();
+    }
+
+    // Masteries
+    @GetMapping("/masteries")
+    public JsonNode getMasteries() {
+        return lolService.getMasteries();
+    }
+
+    @GetMapping("/masteries/{id}")
+    public JsonNode getMastery(@PathVariable("id") String id) {
+        return lolService.getMastery(id);
+    }
+
+    // Matches
+    @GetMapping("/matches")
+    public JsonNode getMatches() {
+        return lolService.getMatches();
+    }
+
+    @GetMapping("/matches/past")
+    public JsonNode getMatchesPast() {
+        return lolService.getMatchesPast();
+    }
+
+    @GetMapping("/matches/running")
+    public JsonNode getMatchesRunning() {
+        return lolService.getMatchesRunning();
+    }
+
+    @GetMapping("/matches/upcoming")
+    public JsonNode getMatchesUpcoming() {
+        return lolService.getMatchesUpcoming();
+    }
+
+    @GetMapping("/matches/{id}")
+    public JsonNode getMatch(@PathVariable("id") String id) {
+        return lolService.getMatch(id);
+    }
+
+    // Players
+    @GetMapping("/players")
+    public JsonNode getPlayers() {
+        return lolService.getPlayers();
+    }
+
+    @GetMapping("/players/{id}")
+    public JsonNode getPlayer(@PathVariable("id") String id) {
+        return lolService.getPlayer(id);
+    }
+
+    // Runes
+    @GetMapping("/runes-reforged")
+    public JsonNode getRunesReforged() {
+        return lolService.getRunesReforged();
+    }
+
+    @GetMapping("/runes-reforged-paths")
+    public JsonNode getRunesReforgedPaths() {
+        return lolService.getRunesReforgedPaths();
+    }
+
+    @GetMapping("/runes-reforged-paths/{id}")
+    public JsonNode getRunesReforgedPath(@PathVariable("id") String id) {
+        return lolService.getRunesReforgedPath(id);
+    }
+
+    @GetMapping("/runes-reforged/{id}")
+    public JsonNode getRuneReforged(@PathVariable("id") String id) {
+        return lolService.getRuneReforged(id);
+    }
+
+    // Series
+    @GetMapping("/series")
+    public JsonNode getSeries() {
+        return lolService.getSeries();
+    }
+
+    @GetMapping("/series/past")
+    public JsonNode getSeriesPast() {
+        return lolService.getSeriesPast();
+    }
+
+    @GetMapping("/series/running")
+    public JsonNode getSeriesRunning() {
+        return lolService.getSeriesRunning();
+    }
+
+    @GetMapping("/series/upcoming")
+    public JsonNode getSeriesUpcoming() {
+        return lolService.getSeriesUpcoming();
+    }
+
+    @GetMapping("/series/{id}/teams")
+    public JsonNode getSeriesTeams(@PathVariable("id") String id) {
+        return lolService.getSeriesTeams(id);
+    }
+
+    // Teams
+    @GetMapping("/teams")
+    public JsonNode getTeams() {
+        return lolService.getTeams();
+    }
+
+    @GetMapping("/teams/{id}")
+    public JsonNode getTeam(@PathVariable("id") String id) {
+        return lolService.getTeam(id);
+    }
+
+    // Spells
+    @GetMapping("/spells")
+    public JsonNode getSpells() {
+        return lolService.getSpells();
+    }
+
+    @GetMapping("/spells/{id}")
+    public JsonNode getSpell(@PathVariable("id") String id) {
+        return lolService.getSpell(id);
+    }
+
+    // Tournaments
+    @GetMapping("/tournaments")
+    public JsonNode getTournaments() {
+        return lolService.getTournaments();
+    }
+
+    @GetMapping("/tournaments/{id}")
+    public JsonNode getTournament(@PathVariable("id") String id) {
+        return lolService.getTournament(id);
+    }
+
+    @GetMapping("/tournaments/past")
+    public JsonNode getTournamentsPast() {
+        return lolService.getTournamentsPast();
+    }
+
+    @GetMapping("/tournaments/running")
+    public JsonNode getTournamentsRunning() {
+        return lolService.getTournamentsRunning();
+    }
+
+    @GetMapping("/tournaments/upcoming")
+    public JsonNode getTournamentsUpcoming() {
+        return lolService.getTournamentsUpcoming();
+    }
+}


### PR DESCRIPTION
## Summary
- add PandaScore client methods for League of Legends endpoints
- create LolService interface and implementation
- expose new `/api/pandascore/lol` controller
- allow LoL resources in favorites

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6852bedc4640832884f23283e3845f91