### PR TITLE
Add Valorant API endpoints and favorites cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ public ResponseEntity<AppUserResponseDto> updateCurrentUser(Principal principal,
 ```
 
 - `DELETE /api/favorites/{id}` – Elimina un favorito.
+- `DELETE /api/favorites` – Borra todos los favoritos del usuario.
 
 Internamente se consulta PandaScore para obtener información del elemento guardado.
 Los valores posibles de `itemType` incluyen los genéricos (`team`, `player`, `match`, `tournament`, `videogame`) y otros específicos como `csgo_team`, `csgo_player`, `dota2_team`, `dota2_player`, etc.
@@ -158,6 +159,7 @@ Bajo `/api/pandascore` existen múltiples rutas para equipos, jugadores, partido
 - `GET /api/pandascore/videogames`
 - Endpoints específicos de CSGO bajo `/api/pandascore/csgo` (maps, weapons, games, etc.).
 - Endpoints de Dota2 bajo `/api/pandascore/dota2` (abilities, heroes, items, matches, etc.).
+- Endpoints de Valorant bajo `/api/pandascore/valorant` (abilities, agents, maps, matches, etc.).
 
 Todas estas rutas devuelven directamente la respuesta de PandaScore en formato JSON.
 

--- a/src/main/java/rjkscore/application/service/FavoriteService.java
+++ b/src/main/java/rjkscore/application/service/FavoriteService.java
@@ -9,4 +9,5 @@ public interface FavoriteService {
     FavoriteResponseDto addFavorite(String username, FavoriteRequestDto dto);
     List<FavoriteResponseDto> getFavorites(String username);
     void removeFavorite(Integer favoriteId, String username);
+    void removeAllFavorites(String username);
 }

--- a/src/main/java/rjkscore/application/service/ValorantService.java
+++ b/src/main/java/rjkscore/application/service/ValorantService.java
@@ -1,0 +1,48 @@
+package rjkscore.application.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface ValorantService {
+    // Abilities
+    JsonNode getAbilities();
+    JsonNode getAbility(String abilityId);
+
+    // Agents
+    JsonNode getAgents();
+    JsonNode getAgent(String agentId);
+
+    // Leagues
+    JsonNode getLeagues();
+
+    // Maps
+    JsonNode getMaps();
+    JsonNode getMap(String mapId);
+
+    // Matches
+    JsonNode getMatches();
+    JsonNode getMatchesPast();
+    JsonNode getMatchesRunning();
+    JsonNode getMatchesUpcoming();
+
+    // Players
+    JsonNode getPlayers();
+
+    // Series
+    JsonNode getSeries();
+    JsonNode getSeriesPast();
+    JsonNode getSeriesRunning();
+    JsonNode getSeriesUpcoming();
+
+    // Teams
+    JsonNode getTeams();
+
+    // Tournaments
+    JsonNode getTournaments();
+    JsonNode getTournamentsPast();
+    JsonNode getTournamentsRunning();
+    JsonNode getTournamentsUpcoming();
+
+    // Weapons
+    JsonNode getWeapons();
+    JsonNode getWeapon(String weaponId);
+}

--- a/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/FavoriteServiceImpl.java
@@ -89,6 +89,15 @@ public List<FavoriteResponseDto> getFavorites(String username) {
                     case "lol_spell" -> itemData = pandaScoreApiClient.getLolSpell(id);
                     case "lol_rune" -> itemData = pandaScoreApiClient.getLolRuneReforged(id);
                     case "lol_rune_path" -> itemData = pandaScoreApiClient.getLolRunesReforgedPath(id);
+                    case "valorant_ability" -> itemData = pandaScoreApiClient.getValorantAbility(id);
+                    case "valorant_agent" -> itemData = pandaScoreApiClient.getValorantAgent(id);
+                    case "valorant_map" -> itemData = pandaScoreApiClient.getValorantMap(id);
+                    case "valorant_match" -> itemData = pandaScoreApiClient.getValorantMatches();
+                    case "valorant_player" -> itemData = pandaScoreApiClient.getValorantPlayers();
+                    case "valorant_series" -> itemData = pandaScoreApiClient.getValorantSeries();
+                    case "valorant_team" -> itemData = pandaScoreApiClient.getValorantTeams();
+                    case "valorant_tournament" -> itemData = pandaScoreApiClient.getValorantTournaments();
+                    case "valorant_weapon" -> itemData = pandaScoreApiClient.getValorantWeapon(id);
                     default -> itemData = null;
                 }
 
@@ -108,5 +117,12 @@ public List<FavoriteResponseDto> getFavorites(String username) {
             throw new RuntimeException("Favorite does not belong to user");
         }
         favoriteRepository.delete(favorite);
+    }
+
+    @Override
+    public void removeAllFavorites(String username) {
+        AppUser user = appUserRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found"));
+        favoriteRepository.deleteByUser(user);
     }
 }

--- a/src/main/java/rjkscore/application/service/impl/ValorantServiceImpl.java
+++ b/src/main/java/rjkscore/application/service/impl/ValorantServiceImpl.java
@@ -1,0 +1,143 @@
+package rjkscore.application.service.impl;
+
+import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.ValorantService;
+import rjkscore.infrastructure.Client.PandaScoreApiClient;
+
+@Service
+public class ValorantServiceImpl implements ValorantService {
+
+    private final PandaScoreApiClient pandaScoreApiClient;
+
+    public ValorantServiceImpl(PandaScoreApiClient pandaScoreApiClient) {
+        this.pandaScoreApiClient = pandaScoreApiClient;
+    }
+
+    // Abilities
+    @Override
+    public JsonNode getAbilities() {
+        return pandaScoreApiClient.getValorantAbilities();
+    }
+
+    @Override
+    public JsonNode getAbility(String abilityId) {
+        return pandaScoreApiClient.getValorantAbility(abilityId);
+    }
+
+    // Agents
+    @Override
+    public JsonNode getAgents() {
+        return pandaScoreApiClient.getValorantAgents();
+    }
+
+    @Override
+    public JsonNode getAgent(String agentId) {
+        return pandaScoreApiClient.getValorantAgent(agentId);
+    }
+
+    // Leagues
+    @Override
+    public JsonNode getLeagues() {
+        return pandaScoreApiClient.getValorantLeagues();
+    }
+
+    // Maps
+    @Override
+    public JsonNode getMaps() {
+        return pandaScoreApiClient.getValorantMaps();
+    }
+
+    @Override
+    public JsonNode getMap(String mapId) {
+        return pandaScoreApiClient.getValorantMap(mapId);
+    }
+
+    // Matches
+    @Override
+    public JsonNode getMatches() {
+        return pandaScoreApiClient.getValorantMatches();
+    }
+
+    @Override
+    public JsonNode getMatchesPast() {
+        return pandaScoreApiClient.getValorantMatchesPast();
+    }
+
+    @Override
+    public JsonNode getMatchesRunning() {
+        return pandaScoreApiClient.getValorantMatchesRunning();
+    }
+
+    @Override
+    public JsonNode getMatchesUpcoming() {
+        return pandaScoreApiClient.getValorantMatchesUpcoming();
+    }
+
+    // Players
+    @Override
+    public JsonNode getPlayers() {
+        return pandaScoreApiClient.getValorantPlayers();
+    }
+
+    // Series
+    @Override
+    public JsonNode getSeries() {
+        return pandaScoreApiClient.getValorantSeries();
+    }
+
+    @Override
+    public JsonNode getSeriesPast() {
+        return pandaScoreApiClient.getValorantSeriesPast();
+    }
+
+    @Override
+    public JsonNode getSeriesRunning() {
+        return pandaScoreApiClient.getValorantSeriesRunning();
+    }
+
+    @Override
+    public JsonNode getSeriesUpcoming() {
+        return pandaScoreApiClient.getValorantSeriesUpcoming();
+    }
+
+    // Teams
+    @Override
+    public JsonNode getTeams() {
+        return pandaScoreApiClient.getValorantTeams();
+    }
+
+    // Tournaments
+    @Override
+    public JsonNode getTournaments() {
+        return pandaScoreApiClient.getValorantTournaments();
+    }
+
+    @Override
+    public JsonNode getTournamentsPast() {
+        return pandaScoreApiClient.getValorantTournamentsPast();
+    }
+
+    @Override
+    public JsonNode getTournamentsRunning() {
+        return pandaScoreApiClient.getValorantTournamentsRunning();
+    }
+
+    @Override
+    public JsonNode getTournamentsUpcoming() {
+        return pandaScoreApiClient.getValorantTournamentsUpcoming();
+    }
+
+    // Weapons
+    @Override
+    public JsonNode getWeapons() {
+        return pandaScoreApiClient.getValorantWeapons();
+    }
+
+    @Override
+    public JsonNode getWeapon(String weaponId) {
+        return pandaScoreApiClient.getValorantWeapon(weaponId);
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
+++ b/src/main/java/rjkscore/infrastructure/Client/PandaScoreApiClient.java
@@ -551,4 +551,97 @@ public class PandaScoreApiClient {
         return fetchList("https://api.pandascore.co/lol/tournaments/upcoming");
     }
 
+    // --- VALORANT endpoints ---
+    public JsonNode getValorantAbilities() {
+        return fetchList("https://api.pandascore.co/valorant/abilities");
+    }
+
+    public JsonNode getValorantAbility(String id) {
+        return fetchList("https://api.pandascore.co/valorant/abilities/" + id);
+    }
+
+    public JsonNode getValorantAgents() {
+        return fetchList("https://api.pandascore.co/valorant/agents");
+    }
+
+    public JsonNode getValorantAgent(String id) {
+        return fetchList("https://api.pandascore.co/valorant/agents/" + id);
+    }
+
+    public JsonNode getValorantLeagues() {
+        return fetchList("https://api.pandascore.co/valorant/leagues");
+    }
+
+    public JsonNode getValorantMaps() {
+        return fetchList("https://api.pandascore.co/valorant/maps");
+    }
+
+    public JsonNode getValorantMap(String id) {
+        return fetchList("https://api.pandascore.co/valorant/maps/" + id);
+    }
+
+    public JsonNode getValorantMatches() {
+        return fetchList("https://api.pandascore.co/valorant/matches");
+    }
+
+    public JsonNode getValorantMatchesPast() {
+        return fetchList("https://api.pandascore.co/valorant/matches/past");
+    }
+
+    public JsonNode getValorantMatchesRunning() {
+        return fetchList("https://api.pandascore.co/valorant/matches/running");
+    }
+
+    public JsonNode getValorantMatchesUpcoming() {
+        return fetchList("https://api.pandascore.co/valorant/matches/upcoming");
+    }
+
+    public JsonNode getValorantPlayers() {
+        return fetchList("https://api.pandascore.co/valorant/players");
+    }
+
+    public JsonNode getValorantSeries() {
+        return fetchList("https://api.pandascore.co/valorant/series");
+    }
+
+    public JsonNode getValorantSeriesPast() {
+        return fetchList("https://api.pandascore.co/valorant/series/past");
+    }
+
+    public JsonNode getValorantSeriesRunning() {
+        return fetchList("https://api.pandascore.co/valorant/series/running");
+    }
+
+    public JsonNode getValorantSeriesUpcoming() {
+        return fetchList("https://api.pandascore.co/valorant/series/upcoming");
+    }
+
+    public JsonNode getValorantTeams() {
+        return fetchList("https://api.pandascore.co/valorant/teams");
+    }
+
+    public JsonNode getValorantTournaments() {
+        return fetchList("https://api.pandascore.co/valorant/tournaments");
+    }
+
+    public JsonNode getValorantTournamentsPast() {
+        return fetchList("https://api.pandascore.co/valorant/tournaments/past");
+    }
+
+    public JsonNode getValorantTournamentsRunning() {
+        return fetchList("https://api.pandascore.co/valorant/tournaments/running");
+    }
+
+    public JsonNode getValorantTournamentsUpcoming() {
+        return fetchList("https://api.pandascore.co/valorant/tournaments/upcoming");
+    }
+
+    public JsonNode getValorantWeapons() {
+        return fetchList("https://api.pandascore.co/valorant/weapons");
+    }
+
+    public JsonNode getValorantWeapon(String id) {
+        return fetchList("https://api.pandascore.co/valorant/weapons/" + id);
+    }
+
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/FavoriteController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/FavoriteController.java
@@ -42,4 +42,10 @@ public class FavoriteController {
         favoriteService.removeFavorite(favoriteId, principal.getName());
         return ResponseEntity.noContent().build();
     }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteAllFavorites(Principal principal) {
+        favoriteService.removeAllFavorites(principal.getName());
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/rjkscore/infrastructure/Controller/ValorantController.java
+++ b/src/main/java/rjkscore/infrastructure/Controller/ValorantController.java
@@ -1,0 +1,146 @@
+package rjkscore.infrastructure.Controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import rjkscore.application.service.ValorantService;
+
+@RestController
+@RequestMapping("/api/pandascore/valorant")
+public class ValorantController {
+
+    private final ValorantService valorantService;
+
+    public ValorantController(ValorantService valorantService) {
+        this.valorantService = valorantService;
+    }
+
+    // Abilities
+    @GetMapping("/abilities")
+    public JsonNode getAbilities() {
+        return valorantService.getAbilities();
+    }
+
+    @GetMapping("/abilities/{id}")
+    public JsonNode getAbility(@PathVariable("id") String id) {
+        return valorantService.getAbility(id);
+    }
+
+    // Agents
+    @GetMapping("/agents")
+    public JsonNode getAgents() {
+        return valorantService.getAgents();
+    }
+
+    @GetMapping("/agents/{id}")
+    public JsonNode getAgent(@PathVariable("id") String id) {
+        return valorantService.getAgent(id);
+    }
+
+    // Leagues
+    @GetMapping("/leagues")
+    public JsonNode getLeagues() {
+        return valorantService.getLeagues();
+    }
+
+    // Maps
+    @GetMapping("/maps")
+    public JsonNode getMaps() {
+        return valorantService.getMaps();
+    }
+
+    @GetMapping("/maps/{id}")
+    public JsonNode getMap(@PathVariable("id") String id) {
+        return valorantService.getMap(id);
+    }
+
+    // Matches
+    @GetMapping("/matches")
+    public JsonNode getMatches() {
+        return valorantService.getMatches();
+    }
+
+    @GetMapping("/matches/past")
+    public JsonNode getMatchesPast() {
+        return valorantService.getMatchesPast();
+    }
+
+    @GetMapping("/matches/running")
+    public JsonNode getMatchesRunning() {
+        return valorantService.getMatchesRunning();
+    }
+
+    @GetMapping("/matches/upcoming")
+    public JsonNode getMatchesUpcoming() {
+        return valorantService.getMatchesUpcoming();
+    }
+
+    // Players
+    @GetMapping("/players")
+    public JsonNode getPlayers() {
+        return valorantService.getPlayers();
+    }
+
+    // Series
+    @GetMapping("/series")
+    public JsonNode getSeries() {
+        return valorantService.getSeries();
+    }
+
+    @GetMapping("/series/past")
+    public JsonNode getSeriesPast() {
+        return valorantService.getSeriesPast();
+    }
+
+    @GetMapping("/series/running")
+    public JsonNode getSeriesRunning() {
+        return valorantService.getSeriesRunning();
+    }
+
+    @GetMapping("/series/upcoming")
+    public JsonNode getSeriesUpcoming() {
+        return valorantService.getSeriesUpcoming();
+    }
+
+    // Teams
+    @GetMapping("/teams")
+    public JsonNode getTeams() {
+        return valorantService.getTeams();
+    }
+
+    // Tournaments
+    @GetMapping("/tournaments")
+    public JsonNode getTournaments() {
+        return valorantService.getTournaments();
+    }
+
+    @GetMapping("/tournaments/past")
+    public JsonNode getTournamentsPast() {
+        return valorantService.getTournamentsPast();
+    }
+
+    @GetMapping("/tournaments/running")
+    public JsonNode getTournamentsRunning() {
+        return valorantService.getTournamentsRunning();
+    }
+
+    @GetMapping("/tournaments/upcoming")
+    public JsonNode getTournamentsUpcoming() {
+        return valorantService.getTournamentsUpcoming();
+    }
+
+    // Weapons
+    @GetMapping("/weapons")
+    public JsonNode getWeapons() {
+        return valorantService.getWeapons();
+    }
+
+    @GetMapping("/weapons/{id}")
+    public JsonNode getWeapon(@PathVariable("id") String id) {
+        return valorantService.getWeapon(id);
+    }
+}

--- a/src/main/java/rjkscore/infrastructure/Repository/FavoriteRepository.java
+++ b/src/main/java/rjkscore/infrastructure/Repository/FavoriteRepository.java
@@ -9,4 +9,5 @@ import rjkscore.Domain.Favorite;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Integer> {
     List<Favorite> findByUser(AppUser user);
+    void deleteByUser(AppUser user);
 }


### PR DESCRIPTION
## Summary
- allow deleting all favorites
- support Valorant as a new PandaScore game
- add Valorant controller and service
- expose Valorant endpoints in `PandaScoreApiClient`
- document new endpoints in README

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6852c420b4f88328814646e62dbf17c4